### PR TITLE
Fixed too wide labels on mobile view activities list -> master

### DIFF
--- a/amelie/activities/templates/activity_list.html
+++ b/amelie/activities/templates/activity_list.html
@@ -50,14 +50,14 @@
                                         {{ activity.begin|date:"d-b (D)" }}
                                     </td>
                                     <td>
-                                        <div class="activity-list-label d-none"
+                                        <div class="activity-list-label"
                                             style="background: #{{ activity.activity_label.color }};">
                                             <span class="activity-list-label-name">
                                                 {{ activity.activity_label.name }}
                                             </span>
                                         </div>
                                         <div class="activity-list-label-icon">
-                                            <img src="{{STATIC_URL}}img/icons/{{ activity.activity_label.icon }}.png" alt="{{ current_activity.activity_label.name }}">
+                                            <img src="{{STATIC_URL}}img/icons/{{ activity.activity_label.icon }}.png" alt="{{ activity.activity_label.name }}">
                                         </div>
                                     </td>
                                     <td>

--- a/amelie/activities/templates/activity_list.html
+++ b/amelie/activities/templates/activity_list.html
@@ -31,7 +31,7 @@
                             <thead>
                             <tr>
                                 <th>{% trans 'Date' %}</th>
-                                <th>{% trans 'Label' %}</th>
+                                <th><p class="activity-list-header-label">{% trans 'Label' %}</p></th>
                                 <th>{% trans 'Activities' %}</th>
                                 <th>{% trans 'Enrollment' %}</th>
                             </tr>
@@ -50,16 +50,19 @@
                                         {{ activity.begin|date:"d-b (D)" }}
                                     </td>
                                     <td>
-                                        <div class="activity-list-label" 
+                                        <div class="activity-list-label d-none"
                                             style="background: #{{ activity.activity_label.color }};">
                                             <span class="activity-list-label-name">
                                                 {{ activity.activity_label.name }}
                                             </span>
                                         </div>
+                                        <div class="activity-list-label-icon">
+                                            <img src="{{STATIC_URL}}img/icons/{{ activity.activity_label.icon }}.png" alt="{{ current_activity.activity_label.name }}">
+                                        </div>
                                     </td>
                                     <td>
                                         <img class="dutch-indicator" src="{{ STATIC_URL }}img/layout/flag_nl.png"
-                                            title="{% trans 'Dutch-only' %}" 
+                                            title="{% trans 'Dutch-only' %}"
                                             alt="{% trans 'Dutch-only' %}">
                                         <a class="activity-{{ activity.activity_type }}"
                                            href="{{ activity.get_absolute_url }}"

--- a/amelie/style/static/css/compiled.css
+++ b/amelie/style/static/css/compiled.css
@@ -12686,16 +12686,32 @@ dd.eventdesk-status-UNREGISTERED a {
   display: none !important;
 }
 .activity-list-label {
-  max-width: 100px;
+  max-width: 130px;
   border-radius: 2.5px;
   display: flex;
   justify-content: center;
   align-items: center;
   border: 1px black solid;
   flex: 1;
+  min-width: 100px;
 }
 .activity-list-label-name {
   color: white;
   padding-left: 10px;
   padding-right: 10px;
+}
+.activity-list-label-icon {
+  display: none;
+  min-width: 20px;
+}
+@media only screen and (max-width: 992px) {
+  .activity-list-label {
+    display: none;
+  }
+  .activity-list-label-icon {
+    display: block;
+  }
+  .activity-list-header-label {
+    display: none;
+  }
 }

--- a/amelie/style/static/less/page-specific/activity_list.less
+++ b/amelie/style/static/less/page-specific/activity_list.less
@@ -1,15 +1,35 @@
 .activity-list-label {
-  max-width: 100px;
+  max-width: 130px;
   border-radius: 2.5px;
   display: flex;
   justify-content: center;
   align-items: center;
   border: 1px black solid;
   flex: 1;
+  min-width: 100px;
 }
 
 .activity-list-label-name {
   color: white;
   padding-left: 10px;
   padding-right: 10px;
+}
+
+.activity-list-label-icon {
+  display: none;
+  min-width: 20px;
+}
+
+@media only screen and (max-width: 992px) {
+  .activity-list-label {
+    display: none;
+  }
+
+  .activity-list-label-icon {
+    display: block;
+  }
+
+  .activity-list-header-label {
+    display: none;
+  }
 }


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
It fixes the too wide activity labels on mobile view

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
#674 

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
yes, I've compiled my CSS

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes
