### PR TITLE
Remove the eleven check from the employee form

### DIFF
--- a/amelie/members/forms.py
+++ b/amelie/members/forms.py
@@ -9,7 +9,7 @@ import re
 
 from django import forms
 from django.conf import settings
-from django.core.validators import MaxValueValidator
+from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db.models import Q, TextChoices
 from django.forms import widgets
 from django.forms.models import BaseInlineFormSet
@@ -574,7 +574,7 @@ class RegistrationFormStepFreshmenStudyDetails(forms.Form):
 
 
 class RegistrationFormStepEmployeeDetails(forms.Form):
-    employee_number = forms.IntegerField(validators=[CheckDigitValidator(7), MaxValueValidator(9999999)])
+    employee_number = forms.IntegerField(validators=[MinValueValidator(7640000), MaxValueValidator(9999999)])
 
     def clean_employee_number(self):
         if Employee.objects.filter(number=self.cleaned_data['employee_number']).exists():


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
 It removes the eleven check from the employee member form, so (new) employees can become an Inter-Actief member.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes Inter-Actief/amelie#546

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
 No, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
 no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes
