### PR TITLE
Revert "Added widget for members, and in other place for board"

### DIFF
--- a/templates/frontpage.html
+++ b/templates/frontpage.html
@@ -101,14 +101,6 @@
         {% endif %}
         {# End video things #}
 
-        {# Member view: discord page things #}
-        {% if user.is_authenticated  and not request.is_board%}
-            <div id="discord" class="current">
-                <iframe src="https://discord.com/widget?id=613755161633882112&theme=light" style="width: 100%; height: 100%; min-height: 40em" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
-             </div>
-        {%  endif %}
-        {# End member view: discord page things #}
-
         {# Board things #}
         {% if user.is_authenticated and request.is_board %}
             <div class="ia">
@@ -260,14 +252,6 @@
                     </div>
                 {% endif %}
                 {# End education complaint things #}
-
-                {# Board view: discord page things #}
-                {% if user.is_authenticated and request.is_board%}
-                    <div id="discord" class="current" style="margin-bottom: 2em;">
-                        <iframe src="https://discord.com/widget?id=613755161633882112&theme=light" style="width: 100%; height: 100%; min-height: 40em" allowtransparency="true" frameborder="0" sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"></iframe>
-                    </div>
-                {%  endif %}
-                {# End board view: discord page things #}
             </div>
         </div>
     </div>


### PR DESCRIPTION
Reverts Inter-Actief/amelie#700

The widget actually does set two third party cookies on the discord.com domain, which is currently not allowed by our privacy policy. So we have to revert this for now.

![image](https://user-images.githubusercontent.com/1193988/214144824-49a76f4f-b282-451b-8538-248d16c96bd2.png)


We can look in to changing the policy, which would require us to add a cookie banner (I would vote against this), or try to use the discord API to build our own 'widget' with a similar view, that does not use cookies.