### PR TITLE
Switch between language tabs in case of missing fields

### DIFF
--- a/amelie/members/templates/includes/query/query_mailing.html
+++ b/amelie/members/templates/includes/query/query_mailing.html
@@ -3,6 +3,32 @@
 
 {% block titel %}{% trans "Send mailing" %}{% endblock titel %}
 
+{% block head %}
+    <script>
+    languages = {
+        "en": "nl",
+        "nl": "en",
+    }
+
+    $(document).ready(() => {
+        $('form .tabbed-content input, form .tabbed-content textarea').each(function () {
+            this.addEventListener('invalid', function () {
+                let language = $(this).parent().attr('data-language');
+                let selected_language = $('form .tabbed-ticker [data-language=' + language + ']');
+                selected_language.filter('div').attr('style', 'display: block');
+                selected_language.filter('li').addClass('active');
+
+                let other_lang = languages[language];
+                let other_language = $('form .tabbed-ticker [data-language=' + other_lang + ']');
+                other_language.filter('div').attr('style', 'display: none');
+                other_language.filter('li').removeClass('active');
+            });
+        });
+    });
+
+    </script>
+{% endblock head %}
+
 {% block content %}
     {% if previews %}
         <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
@@ -81,12 +107,12 @@
 
                         <div class="tabbed-ticker" style="display:inline-block;">
                             <ul>
-                                <li class="active">NL</li>
-                                <li>EN</li>
+                                <li class="active" data-language="nl">NL</li>
+                                <li data-language="en">EN</li>
                             </ul>
                             <div class="tabbed-content">
-                                <div>{{ form.subject_nl }}</div>
-                                <div>{{ form.subject_en }}</div>
+                                <div data-language="nl">{{ form.subject_nl }}</div>
+                                <div data-language="en">{{ form.subject_en }}</div>
                             </div>
                         </div>
                     </div>
@@ -104,12 +130,12 @@
                         <label> {% trans 'Content:' %} </label>
 
                         <ul>
-                            <li class="active">NL</li>
-                            <li>EN</li>
+                            <li class="active" data-language="nl">NL</li>
+                            <li data-language="en">EN</li>
                         </ul>
                         <div class="tabbed-content">
-                            <div>{{ form.template_nl }}</div>
-                            <div>{{ form.template_en }}</div>
+                            <div data-language="nl">{{ form.template_nl }}</div>
+                            <div data-language="en">{{ form.template_en }}</div>
                         </div>
                     </div>
                     <div class="buttons">


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
When sending out a mailing warnings of missing fields would not be shown for fields that are hidden (in the case of tabs for english and dutch). This PR fixes that by automatically switching to the language that contains a validation error.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes Inter-Actief/amelie#338

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes
