### PR TITLE
Fix FileNotFoundError in www_generate_dummydata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ Replace the `MEDIA_ROOT` and `DATA_EXPORT_ROOT` settings with proper locations. 
 
 For example: *(make sure the directory exists!)*
 
-    MEDIA_ROOT = "/tmp/amelie_uploads/"
+    MEDIA_ROOT = "/tmp/amelie_uploads"
 
 ##### Populate the database
     python manage.py migrate


### PR DESCRIPTION
**Please describe what your PR is fixing**
A potential FileNotFoundError in a manage.py script, due to incorrect documentation.

During the generation of dummydata, the script looks at MEDIA_ROOT and removes an extra character. The tutorial specifies setting `MEDIA_ROOT = "/tmp/amelie_uploads/"`, however, this leads to trying to create `/tmp/amelie_uploads/ata/image/small/2023/04/12/1738-e7316016-c5dc-4dc9-99cd-a168cf11f0c3.png.jpg`.

The fix is to set `MEDIA_ROOT = "/tmp/amelie_uploads"`and NOT `MEDIA_ROOT = "/tmp/amelie_uploads/"`

This issue was found when @00maarten00 was trying to set up amelie on his laptop running Linux. I also verified (and fixed) the issue on MacOS.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
No issue was created for this PR.

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes
