### PR TITLE
Fade non-neighbouring nodes on node selection instead of disappearing them

### DIFF
--- a/amelie/members/static/js/dogroup_tree.js
+++ b/amelie/members/static/js/dogroup_tree.js
@@ -14,6 +14,32 @@ var state = {
 };
 
 /**
+ * A datastructure that holds for each dogroup its generations, parents and colours
+ *
+ * The structure looks as follows:
+ *  dogroup_name: {         # The name of a dogroup (allows for agreggration of generations)
+ *      generation: {       # The year that this dogroup was active
+ *          id,             # The id associated with this generation
+ *          parents: {      # A list of the parents of this dogroup
+ *              id          # The id of the generation from each parent
+ *          },
+ *          color,          # The colour of this generation (by default the color of this dogroup)
+ *      }
+ *  }
+ */
+let data;
+
+/**
+ * All of the years that have at least one active generation of a dogroup
+ */
+let years;
+
+/**
+ * A list of names from all the dogroups
+ */
+let dogroups;
+
+/**
  * Store nodes on a hover event.
  * @param node The node that is being hovered over.
  */
@@ -42,9 +68,9 @@ window.addEventListener('DOMContentLoaded', async function() {
    // Load all the data objects.
    // You want to do this asynchronous, since loading this data might take quite a while
    let response = await fetch("/members/dogroups/data").then(res => res.json());
-   let dogroups = response.dogroups;
-   let years = response.years;
-   let data = response.data;
+   dogroups = response.dogroups;
+   years = response.years;
+   data = response.data;
 
    // Give every dogroup its own x coordinate
    let dogroup_x_coords = {};
@@ -106,8 +132,8 @@ window.addEventListener('DOMContentLoaded', async function() {
       const res = {...data};
 
       if (state.hoveredNeighbours && !state.hoveredNeighbours.includes(node) && state.hoveredNode !== node) {
-         res.label = "";
-         res.color = "#f6f6f6";
+         // Set opacity (but hey that is of course supported :), so hotfix instead!)
+         res.color = res.color.slice(0, 7) + "60";
       }
 
       return res;


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
When people hover over the do-group family tree, all of the non-neighbouring nodes from the selected node disappear. However, this can cause quite some accidental flickering. In order to battle this the opacity of the non-neighbouring nodes is lowered, instead of completely removing them.

Additionally, I've added some documentation to the already existing code. 

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Inter-Actief/amelie#780

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes
