### PR TITLE
Fix exception on ClearableFileInput in Django 3.2.19 and higher

### DIFF
--- a/amelie/activities/forms.py
+++ b/amelie/activities/forms.py
@@ -254,8 +254,26 @@ class PhotoUploadForm(forms.Form):
                                                                      function__end__isnull=True).distinct()
 
 
+class MultipleFileInput(forms.ClearableFileInput):
+    allow_multiple_selected = True
+
+
+class MultipleFileField(forms.FileField):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("widget", MultipleFileInput())
+        super().__init__(*args, **kwargs)
+
+    def clean(self, data, initial=None):
+        single_file_clean = super().clean
+        if isinstance(data, (list, tuple)):
+            result = [single_file_clean(d, initial) for d in data]
+        else:
+            result = single_file_clean(data, initial)
+        return result
+
+
 class PhotoFileUploadForm(forms.Form):
-    photo_files = forms.FileField(widget=forms.ClearableFileInput(attrs={'multiple': True}))
+    photo_files = MultipleFileField()
 
     def clean_photo_files(self):
         allowed_extensions = ["jpg", "jpeg", "gif"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=3.2.16,<3.2.18  # Limited because of issue https://github.com/Inter-Actief/amelie/issues/760
+Django>=3.2.16,<3.3
 
 importlib-metadata>=1.4.0,<5.0  # importlib-metadata 5+ causes Celery bug: https://github.com/celery/celery/issues/7783
 celery>=5.2.7,<5.3


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
Fixes the exception we got on Django 3.2.19+ on the clearable file input field.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes #760 

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes
