### PR TITLE
Send an email for newly enrolled members

### DIFF
--- a/amelie/members/templates/members/new_member.mail
+++ b/amelie/members/templates/members/new_member.mail
@@ -1,0 +1,12 @@
+{% extends "iamailer/email_basic.mail" %}
+{% load i18n htmlify only %}
+
+{% block subject %}{% blocktrans %}[Inter-Actief] Welcome human!{% endblocktrans %}{% endblock %}
+
+{% block content %}{% htmlify %}{% blocktrans %}Dear{% endblocktrans %} {{ recipient.first_name }},
+
+{% blocktrans %}Hereby, Vadim would like to welcome you to our beautiful association. May the cookie corner credit be in your favour.{% endblocktrans %}
+
+{% blocktrans %}Kind regards,
+
+The board of Inter-Actief{% endblocktrans %}{% endhtmlify %}{% endblock %}


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
When a new member is enrolled, they will receive an email.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes Inter-Actief/amelie#720

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
yes, however after the email template has been updated the translations should be added

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
no, testing the entire mail system is quite hard due to the need to enroll members and finalize all of the steps. This feature has only been tested for creating external members. 
