### PR TITLE
Fix photo archive link and display

### DIFF
--- a/amelie/activities/templates/gallery_overview.html
+++ b/amelie/activities/templates/gallery_overview.html
@@ -235,7 +235,7 @@
         </div>
     </div>
 
-    {% if pagina.number == 1 %}
+    {% if page.number == 1 %}
         <div class="col-xs-12">
             <div class="current">
                 <h2>{% trans 'Photo archive' %}</h2>
@@ -244,7 +244,7 @@
                     <p>
                         {% blocktrans %}
                             The photo archive with photos from 2000 till march 2009 can be found on
-                            <a href="https://foto.inter-actief.net/">foto.inter-actief.net</a>.
+                            <a href="https://inter-actief.net/foto">inter-actief.net/foto</a>.
                         {% endblocktrans %}
                     </p>
                 </div>


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
Display the photo archive with the correct link in the gallery_overview.html page.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes #725.

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
No

**Does your PR include any django migrations?**
No

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
No, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
No, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
No

**Did you properly test your PR before submitting it?**
Yes
<img width="1234" alt="image" src="https://github.com/Inter-Actief/amelie/assets/45125673/2055b669-0e62-468b-88f3-79dbfe400013">
