### PR TITLE
education: Fix comment editing not removing all text

### DIFF
--- a/amelie/education/templates/complaint.html
+++ b/amelie/education/templates/complaint.html
@@ -134,7 +134,9 @@
                                     {% endif %}
                                 </td>
                                 <td>
-                                    {{ comment.comment|markdown }}
+                                    <div class="comment_content">
+                                        {{ comment.comment|markdown }}
+                                    </div>
                                     {% if request.is_education_committee or comment.person == request.person %}
                                         <br/>
                                         <input type="submit" class="complaint_comment_save" name="edit" value="{% trans 'Save comment' %}">

--- a/amelie/style/static/js/amelie.js
+++ b/amelie/style/static/js/amelie.js
@@ -377,9 +377,9 @@ $(document).ready(function() {
 			var commentBody = $(this).siblings('.complaint_comment_value');
 			commentPlace.children('input').toggleClass("complaint_comment_save");
 			commentPlace.prepend(
-				'<textarea cols="60">' + commentBody.val() + '</textarea>'
+				'<textarea cols="60" rows="20">' + commentBody.val() + '</textarea>'
 			);
-			commentPlace.children("p").remove();
+			commentPlace.children("div.comment_content").remove();
 			commentPlace.children('textarea').first().change(function (event) {
 				commentBody.val(event.target.value)
 			});


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
Fixes not all text in complaint comments not being removed when editing a comment

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes #726 

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes
