### PR TITLE
Add the activities module to graphql

### DIFF
--- a/amelie/activities/graphql.py
+++ b/amelie/activities/graphql.py
@@ -1,0 +1,57 @@
+import graphene
+from django_filters import FilterSet
+from graphene_django import DjangoObjectType
+
+from amelie.activities.models import Activity
+from amelie.graphql.pagination.connection_field import DjangoPaginationConnectionField
+
+
+class ActivityFilterSet(FilterSet):
+    class Meta:
+        model = Activity
+        fields = {
+            'id': ("exact", ),
+            'summary_nl': ("icontains", "iexact"),
+            'summary_en': ("icontains", "iexact"),
+            'begin': ("gt", "lt", "exact"),
+            'end': ("gt", "lt", "exact"),
+            'dutch_activity': ("exact", ),
+        }
+
+
+class ActivityType(DjangoObjectType):
+    class Meta:
+        model = Activity
+        fields = [
+            "id",
+            "begin",
+            "end",
+            "entire_day",
+            "summary_nl",
+            "summary_en",
+            "promo_nl",
+            "promo_en",
+            "description_nl",
+            "description_en",
+            "organizer",
+            "location",
+            "public",
+            "attachments",
+            "dutch_activity",
+            "callback_url",
+            "callback_secret_key"
+        ]
+        filterset_class = ActivityFilterSet
+
+
+class ActivitiesQuery(graphene.ObjectType):
+    activities = DjangoPaginationConnectionField(ActivityType, organizer=graphene.ID())
+
+    def resolve_activities(self, info, organizer=None, *args, **kwargs):
+        if organizer:
+            return Activity.objects.filter(organizer__pk=organizer)
+        return Activity.objects.all()
+
+# Exports
+GRAPHQL_QUERIES = [ActivitiesQuery]
+GRAPHQL_MUTATIONS = []

--- a/amelie/activities/graphql.py
+++ b/amelie/activities/graphql.py
@@ -2,7 +2,8 @@ import graphene
 from django_filters import FilterSet
 from graphene_django import DjangoObjectType
 
-from amelie.activities.models import Activity
+from amelie.activities.models import Activity, ActivityLabel
+from amelie.files.models import Attachment
 from amelie.graphql.pagination.connection_field import DjangoPaginationConnectionField
 
 
@@ -39,9 +40,91 @@ class ActivityType(DjangoObjectType):
             "attachments",
             "dutch_activity",
             "callback_url",
-            "callback_secret_key"
+            "enrollment",
+            "enrollment_begin",
+            "enrollment_end",
+            "maximum",
+            "waiting_list_locked",
+            "photos",
+            "components",
+            "price",
+            "can_unenroll",
+            "image_icon",
+            "activity_label"
         ]
         filterset_class = ActivityFilterSet
+
+    absolute_url = graphene.String()
+    random_photo_url = graphene.String()
+    photo_url = graphene.String()
+    calendar_url = graphene.String()
+    enrollment_open = graphene.Boolean()
+    enrollment_closed = graphene.Boolean()
+    can_edit = graphene.Boolean()
+    places_available = graphene.Int()
+    enrollment_full = graphene.Boolean()
+    has_waiting_participants = graphene.Boolean()
+    enrollment_almost_full = graphene.Boolean()
+    has_enrollment_options = graphene.Boolean()
+    has_costs = graphene.Boolean()
+    # TODO: Figure out on how to use foreign keys here!
+
+    def resolve_absolute_url(self: Activity, info):
+        return self.get_absolute_url()
+
+    def resolve_random_photo_url(self: Activity, info):
+        return self.get_photo_url_random()
+
+    def resolve_photo_url(self: Activity, info):
+        return self.get_photo_url()
+
+    def resolve_calendar_url(self: Activity, info):
+        return self.get_calendar_url()
+
+    def resolve_enrollment_open(self: Activity, info):
+        return self.get_enrollment_open()
+
+    def resolve_enrollment_closed(self: Activity, info):
+        return self.get_enrollment_closed()
+
+    def resolve_can_edit(self: Activity, info):
+        if hasattr(info.context.user, 'person'):
+            return self.can_edit(info.context.user.person)
+        return False
+
+    def resolve_places_available(self: Activity, info):
+         return self.places_available()
+
+    def resolve_enrollment_full(self: Activity, info):
+        return self.enrollment_full()
+
+    def resolve_has_waiting_participants(self: Activity, info):
+        return self.has_waiting_participants()
+
+    def resolve_enrollment_almost_full(self: Activity, info):
+        return self.enrollment_almost_full()
+
+    def resolve_has_enrollment_option(self: Activity, info):
+        return self.has_enrollmentoption()
+
+    def resolve_has_costs(self: Activity, info):
+        return self.has_costs()
+
+    # TODO: Write custom resolvers and attributes for functions defined on the events class (inherited by Activity)
+
+
+class ActivityLabelType(DjangoObjectType):
+    class Meta:
+        model = ActivityLabel
+        fields = [
+            "name_en",
+            "name_nl",
+            "color",
+            "icon",
+            "explanation_en",
+            "explanation_nl",
+            "active"
+        ]
 
 
 class ActivitiesQuery(graphene.ObjectType):

--- a/amelie/activities/graphql.py
+++ b/amelie/activities/graphql.py
@@ -67,6 +67,11 @@ class ActivityType(DjangoObjectType):
     enrollment_almost_full = graphene.Boolean()
     has_enrollment_options = graphene.Boolean()
     has_costs = graphene.Boolean()
+    summary = graphene.String()
+    description = graphene.String()
+    promo = graphene.String()
+    description_short = graphene.String()
+
     # TODO: Figure out on how to use foreign keys here!
 
     def resolve_absolute_url(self: Activity, info):
@@ -110,7 +115,17 @@ class ActivityType(DjangoObjectType):
     def resolve_has_costs(self: Activity, info):
         return self.has_costs()
 
-    # TODO: Write custom resolvers and attributes for functions defined on the events class (inherited by Activity)
+    def resolve_summary(self: Activity, info):
+        return self.summary
+
+    def resolve_description(self: Activity, info):
+        return self.description
+
+    def resolve_promo(self: Activity, info):
+        return self.promo1
+
+    def resolve_description_short(self: Activity, info):
+        return self.description_short()
 
 
 class ActivityLabelType(DjangoObjectType):

--- a/amelie/files/graphql.py
+++ b/amelie/files/graphql.py
@@ -1,0 +1,38 @@
+import graphene
+from graphene_django import DjangoObjectType
+
+from amelie.files.models import Attachment
+
+
+class AttachmentType(DjangoObjectType):
+    class Meta:
+        model = Attachment
+        fields = [
+            "file",
+            "caption",
+            "thumb_small",
+            "thumb_medium",
+            "thumb_large",
+            "mimetype",
+            "owner",
+            "created",
+            "modified",
+            "thumb_small_height",
+            "thumb_small_width",
+            "thumb_medium_height",
+            "thumb_medium_width",
+            "thumb_large_height",
+            "thumb_large_width",
+            "public"
+        ]
+
+
+class FilesQuery(graphene.ObjectType):
+    attachment = graphene.Field(AttachmentType, id=graphene.ID())
+
+    def resolve_attachment(root, info, id):
+        return Attachment.objects.get(pk=id)
+
+
+GRAPHQL_QUERIES = [FilesQuery]
+GRAPHQL_MUTATIONS = []

--- a/amelie/settings/generic.py
+++ b/amelie/settings/generic.py
@@ -403,6 +403,7 @@ GRAPHQL_JWT = {
 GRAPHQL_SCHEMAS = [
     "amelie.activities.graphql",
     "amelie.education.graphql",
+    "amelie.files.graphql",
     "amelie.members.graphql",
     "amelie.news.graphql",
     "amelie.publications.graphql",

--- a/amelie/settings/generic.py
+++ b/amelie/settings/generic.py
@@ -401,6 +401,7 @@ GRAPHQL_JWT = {
 }
 
 GRAPHQL_SCHEMAS = [
+    "amelie.activities.graphql",
     "amelie.education.graphql",
     "amelie.members.graphql",
     "amelie.news.graphql",


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
Add the public accessible data from the activities application to the GraphQL API

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes Inter-Actief/amelie#811

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes
