### PR TITLE
503: Process the q query string for photos

### DIFF
--- a/amelie/activities/views.py
+++ b/amelie/activities/views.py
@@ -892,7 +892,14 @@ def gallery(request, pk, page=1):
 
 
 def photos(request, page=1):
-    activities = Activity.objects.filter_public(request).filter(photos__gt=0).distinct().order_by('-end')
+    filters = Q(photos__gt=0)
+    if "q" in request.GET:
+        query = request.GET["q"]
+        # No requirement of 3 characters or more because the request is not a
+        # dynamic input field and will therefore stress the server less.
+        filters &= Q(summary_nl__icontains=query) | Q(summary_en__icontains=query)
+
+    activities = Activity.objects.filter_public(request).filter(filters).distinct().order_by('-end')
 
     only_public = not hasattr(request, 'user') or not request.user.is_authenticated
     if only_public:


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
Previously the 'q' query string was not processed and the server would return all photo albums. Now a filter is applied as expected and only matching albums are returned. The search box on the website will only process a request once more than 2 characters are entered to prevent excessive traffic to and from the server. Since the query string is not automatically sent this restriction has not been applied on the query string.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
`Fixes/References Inter-Actief/amelie#503`

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes
Tested the home page, the photo page with no search, "pu" and "pum".
