### PR TITLE
719: Order photos by creation time.

### DIFF
--- a/amelie/files/models.py
+++ b/amelie/files/models.py
@@ -145,7 +145,7 @@ class Attachment(models.Model):
     objects = AttachmentManager()
 
     class Meta:
-        ordering = ['file']
+        ordering = ['created', 'file']
         verbose_name = _('Appendix')
         verbose_name_plural = _('Attachments')
 


### PR DESCRIPTION
Previously the albums were effectively randomly sorted. Now we look at the creation time in the database. This is not perfect if we want to order on when a photo was taken, but it is a lot better than before at no significant performance penalty or database change.

Please add the following information to your pull request:

**Please describe what your PR is fixing**
Previously the albums were effectively randomly sorted. Now we look at
the creation time in the database. This is not perfect if we want to
order on when a photo was taken, but it is a lot better than before at
no significant performance penalty or database change.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
`Fixes Inter-Actief/amelie#719`

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes, I checked activity 6776 on the beta server and the first 16 photos were correctly sorted looking at the logged file path which included timestamps (when the photo was taken probably), and an incrementing image number that looked good.