### PR TITLE
432-gettext-gettext_lazy: use consistent import as for gettext's

### DIFF
--- a/amelie/about/models.py
+++ b/amelie/about/models.py
@@ -2,23 +2,23 @@ from django.urls import reverse
 from django.db import models
 from django.template.defaultfilters import slugify
 from django.utils.translation import get_language
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 
 class Page(models.Model):
-    name_nl = models.CharField(max_length=100, verbose_name=_('Name'))
-    name_en = models.CharField(max_length=100, verbose_name=_('Name (en)'), blank=True)
+    name_nl = models.CharField(max_length=100, verbose_name=_l('Name'))
+    name_en = models.CharField(max_length=100, verbose_name=_l('Name (en)'), blank=True)
     slug_nl = models.SlugField(max_length=100, editable=False)
     slug_en = models.SlugField(max_length=100, editable=False)
-    educational = models.BooleanField(default=False, verbose_name=_("Educational page?"))
-    content_nl = models.TextField(verbose_name=_('Content'))
-    content_en = models.TextField(verbose_name=_('Content (en)'), blank=True)
+    educational = models.BooleanField(default=False, verbose_name=_l("Educational page?"))
+    content_nl = models.TextField(verbose_name=_l('Content'))
+    content_en = models.TextField(verbose_name=_l('Content (en)'), blank=True)
     last_modified = models.DateTimeField(auto_now=True)
 
     class Meta:
         ordering = ['name_nl']
-        verbose_name = _('Page')
-        verbose_name_plural = _("Pages")
+        verbose_name = _l('Page')
+        verbose_name_plural = _l("Pages")
 
     def __str__(self):
         return self.name

--- a/amelie/activities/feeds.py
+++ b/amelie/activities/feeds.py
@@ -1,14 +1,14 @@
 from django.contrib.syndication.views import Feed
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.activities.models import Activity
 
 
 class Activities(Feed):
     link = '/activities/'
-    title = _('IA Events')
-    description = _('Inter-Actief\'s activities in the coming weeks')
+    title = _l('IA Events')
+    description = _l('Inter-Actief\'s activities in the coming weeks')
 
     title_template = "feeds/news_title.html"
     description_template = "feeds/news_content.html"

--- a/amelie/activities/forms.py
+++ b/amelie/activities/forms.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError
 from pathlib import Path
 from django.forms import widgets, SplitDateTimeField
 from django.utils import formats, timezone
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.activities.models import Activity, EnrollmentoptionQuestion, \
     EnrollmentoptionCheckbox, EnrollmentoptionCheckboxAnswer, \
@@ -25,7 +25,7 @@ class PaymentForm(forms.Form):
             (Participation.PaymentMethodChoices.CASH.value,
              Participation.PaymentMethodChoices.CASH.label),
         ],
-        label=_('Method of payment'))
+        label=_l('Method of payment'))
 
     def __init__(self, mandate=False, waiting_list=False, board=False, *args, **kwargs):
         super(PaymentForm, self).__init__(*args, **kwargs)
@@ -38,17 +38,17 @@ class PaymentForm(forms.Form):
 
         if waiting_list:
             self.fields['waiting_list'] = forms.ChoiceField(choices=[
-                ('Wait', _("Place on bottom of waiting list")),
-            ], label=_("Waiting list action"))
+                ('Wait', _l("Place on bottom of waiting list")),
+            ], label=_l("Waiting list action"))
             if board:
                 choices = self.fields['waiting_list'].choices
-                choices.append(('Skip', _("Skip waiting list and enroll immediately")))
+                choices.append(('Skip', _l("Skip waiting list and enroll immediately")))
                 self.fields['waiting_list'].choices = choices
 
 
 class ActivityForm(forms.ModelForm):
 
-    price = forms.DecimalField(required=False, initial="0.00", min_value=0, decimal_places=2, label=_('Price'))
+    price = forms.DecimalField(required=False, initial="0.00", min_value=0, decimal_places=2, label=_l('Price'))
 
     class Meta:
         model = Activity
@@ -93,18 +93,18 @@ class ActivityForm(forms.ModelForm):
             self.cleaned_data['price'] = 0
 
         if self.cleaned_data["price"] > settings.PERSONAL_TAB_MAXIMUM_ACTIVITY_PRICE and self.cleaned_data["enrollment"]:
-            raise forms.ValidationError(_("Website enrolment has a maximum of {0} euro. Either turn off the ability to enrol or decrease the cost of the activity.").format(settings.PERSONAL_TAB_MAXIMUM_ACTIVITY_PRICE))
+            raise forms.ValidationError(_l("Website enrolment has a maximum of {0} euro. Either turn off the ability to enrol or decrease the cost of the activity.").format(settings.PERSONAL_TAB_MAXIMUM_ACTIVITY_PRICE))
 
         if self.cleaned_data["enrollment"]:
             if not self.cleaned_data.get('enrollment_begin', None):
-                self.add_error('enrollment_begin', _('There is no enrollment start date entered.'))
+                self.add_error('enrollment_begin', _l('There is no enrollment start date entered.'))
 
             if not self.cleaned_data.get('enrollment_end'):
-                self.add_error('enrollment_end', _('There is no enrollment end date entered.'))
+                self.add_error('enrollment_end', _l('There is no enrollment end date entered.'))
 
             if self.cleaned_data.get('enrollment_begin', None) and self.cleaned_data.get('enrollment_stop', None) \
                     and self.cleaned_data['enrollment_stop'] < self.cleaned_data['enrollment_begin']:
-                self.add_error('enrollment_stop', _("Signup end must be after the signup start."))
+                self.add_error('enrollment_stop', _l("Signup end must be after the signup start."))
 
         return self.cleaned_data
 
@@ -185,7 +185,7 @@ class EnrollmentoptionCheckboxAnswerForm(EnrollmentoptionAnswerForm):
     def clean_answer(self):
         data = self.cleaned_data['answer']
         if data and not self.enrollmentoption.spots_left():
-            self.add_error('answer', _("Sorry, but the last spot has been claimed already!"))
+            self.add_error('answer', _l("Sorry, but the last spot has been claimed already!"))
         return data
 
     class Meta:
@@ -207,9 +207,9 @@ class EnrollmentoptionNumericAnswerForm(EnrollmentoptionAnswerForm):
         if not data:
             data = 0
         if max_per_person is not None and data > max_per_person:
-            self.add_error('answer', _("Sorry, but you cannot exceed the maximum amount per person!"))
+            self.add_error('answer', _l("Sorry, but you cannot exceed the maximum amount per person!"))
         if data > 0 and not self.enrollmentoption.spots_left():
-            self.add_error('answer', _("Sorry, but there are not enough spots left!"))
+            self.add_error('answer', _l("Sorry, but there are not enough spots left!"))
         return data
 
     class Meta:
@@ -232,17 +232,17 @@ class PhotoCheckboxSelectMultiple(widgets.CheckboxSelectMultiple):
 
 
 class PhotoUploadForm(forms.Form):
-    photographer = forms.ModelChoiceField(Person.objects.none(), label=_('Photographer'), required=False)
-    first_name = forms.CharField(max_length=50, label=_('First name'), required=False,
-                                 help_text=_('Use this field if a non-member is the owner of these pictures'))
-    last_name_prefix = forms.CharField(max_length=25, label=_('Last name pre-fix'), required=False,
-                                       help_text=_('Use this field if a non-member is the owner of these pictures'))
-    last_name = forms.CharField(max_length=50, label=_('Last name'), required=False,
-                                help_text=_('Use this field if a non-member is the owner of these pictures'))
-    activity = ActivityModelChoiceField(Activity.objects.none(), label=_('Activities'))
-    public = forms.BooleanField(label=_('Public'), required=False,
-                                help_text=_('Photos are also available without logging in'), initial=True)
-    photos = forms.MultipleChoiceField(widget=PhotoCheckboxSelectMultiple, label=_('Photos'))
+    photographer = forms.ModelChoiceField(Person.objects.none(), label=_l('Photographer'), required=False)
+    first_name = forms.CharField(max_length=50, label=_l('First name'), required=False,
+                                 help_text=_l('Use this field if a non-member is the owner of these pictures'))
+    last_name_prefix = forms.CharField(max_length=25, label=_l('Last name pre-fix'), required=False,
+                                       help_text=_l('Use this field if a non-member is the owner of these pictures'))
+    last_name = forms.CharField(max_length=50, label=_l('Last name'), required=False,
+                                help_text=_l('Use this field if a non-member is the owner of these pictures'))
+    activity = ActivityModelChoiceField(Activity.objects.none(), label=_l('Activities'))
+    public = forms.BooleanField(label=_l('Public'), required=False,
+                                help_text=_l('Photos are also available without logging in'), initial=True)
+    photos = forms.MultipleChoiceField(widget=PhotoCheckboxSelectMultiple, label=_l('Photos'))
 
     def __init__(self, photos, *args, **kwargs):
         super(PhotoUploadForm, self).__init__(*args, **kwargs)
@@ -281,7 +281,7 @@ class PhotoFileUploadForm(forms.Form):
             extension = Path(file.name).suffix[1:].lower()
             if extension not in allowed_extensions:
                 raise ValidationError(
-                    message=_('File extension “%(extension)s” is not allowed. '
+                    message=_l('File extension “%(extension)s” is not allowed. '
                               'Allowed extensions are: %(allowed_extensions)s.'),
                     code='invalid_extension',
                     params={'extension': extension,
@@ -291,7 +291,7 @@ class PhotoFileUploadForm(forms.Form):
 
 
 class EventDeskActivityMatchForm(forms.Form):
-    activity = ActivityModelChoiceField(Activity.objects.none(), label=_('Activity'))
+    activity = ActivityModelChoiceField(Activity.objects.none(), label=_l('Activity'))
 
     def __init__(self, activities, *args, **kwargs):
         super(EventDeskActivityMatchForm, self).__init__(*args, **kwargs)

--- a/amelie/activities/mail.py
+++ b/amelie/activities/mail.py
@@ -5,7 +5,7 @@ from amelie.iamailer import MailTask, Recipient
 from amelie.members.models import Preference
 from amelie.tools.calendar import ical_calendar
 from amelie.tools.mail import PersonRecipient
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 
 def activity_send_cashrefundmail(cash_participants, activity, request):
@@ -59,9 +59,9 @@ def activity_send_enrollmentmail(participation, from_waiting_list=False):
         if from_waiting_list:
             template_name = "activities/activity_enrolled_from_waiting_list.mail"
 
-        task = MailTask(from_=_(u'Inter-Activity') + ' <bestuur@inter-actief.net>',
+        task = MailTask(from_=_l(u'Inter-Activity') + ' <bestuur@inter-actief.net>',
                         template_name=template_name,
-                        report_to=_(u'Inter-Activity') + ' <bestuur@inter-actief.net>', report_always=False)
+                        report_to=_l(u'Inter-Activity') + ' <bestuur@inter-actief.net>', report_always=False)
         task.add_recipient(PersonRecipient(
             recipient=person,
             context={'activity': activity,
@@ -124,9 +124,9 @@ def activity_send_on_waiting_listmail(participation):
             invite = False
             attachments = []
 
-        task = MailTask(from_=_('Inter-Activity') + ' <bestuur@inter-actief.net>',
+        task = MailTask(from_=_l('Inter-Activity') + ' <bestuur@inter-actief.net>',
                         template_name='activities/activity_enrolled_on_waiting_list.mail',
-                        report_to=_('Inter-Activity') + ' <bestuur@inter-actief.net>', report_always=False)
+                        report_to=_l('Inter-Activity') + ' <bestuur@inter-actief.net>', report_always=False)
         task.add_recipient(PersonRecipient(
             recipient=person,
             context={'activity': activity,

--- a/amelie/activities/models.py
+++ b/amelie/activities/models.py
@@ -9,7 +9,7 @@ from django.db import models
 from django.db.models.signals import post_save, pre_save
 from django.utils import timezone
 from django.utils.timezone import make_aware
-from django.utils.translation import get_language, gettext_lazy as _
+from django.utils.translation import get_language, gettext_lazy as _l
 from oauth2_provider.models import Application
 
 from amelie.activities.utils import setlocale, update_waiting_list
@@ -22,13 +22,13 @@ from amelie.tools.managers import SubclassManager
 
 
 class ActivityLabel(models.Model):
-    name_en = models.CharField(verbose_name=_("Name (en)"), max_length=32)
-    name_nl = models.CharField(verbose_name=_("Name"), max_length=32)
-    color = models.CharField(verbose_name=_("Hexcolor without #"), max_length=6)
-    icon = models.CharField(verbose_name=_("Icon from known icons"), max_length=32)
-    explanation_en = models.TextField(verbose_name=_("Explanation on icon (en)"))
-    explanation_nl = models.TextField(verbose_name=_("Explanation on icon"))
-    active = models.BooleanField(verbose_name=_("Active?"), default=True)
+    name_en = models.CharField(verbose_name=_l("Name (en)"), max_length=32)
+    name_nl = models.CharField(verbose_name=_l("Name"), max_length=32)
+    color = models.CharField(verbose_name=_l("Hexcolor without #"), max_length=6)
+    icon = models.CharField(verbose_name=_l("Icon from known icons"), max_length=32)
+    explanation_en = models.TextField(verbose_name=_l("Explanation on icon (en)"))
+    explanation_nl = models.TextField(verbose_name=_l("Explanation on icon"))
+    active = models.BooleanField(verbose_name=_l("Active?"), default=True)
 
     @property
     def name(self):
@@ -55,21 +55,21 @@ class ActivityLabel(models.Model):
 
 
 class Activity(Event):
-    enrollment = models.BooleanField(default=False, verbose_name=_('enrollment'))
-    enrollment_begin = models.DateTimeField(blank=True, null=True, verbose_name=_('enrollment start'), help_text=_('If you want to add options, make sure your activity isn\'t open for enrollment right away'))
-    enrollment_end = models.DateTimeField(blank=True, null=True, verbose_name=_('enrollment end'))
+    enrollment = models.BooleanField(default=False, verbose_name=_l('enrollment'))
+    enrollment_begin = models.DateTimeField(blank=True, null=True, verbose_name=_l('enrollment start'), help_text=_l('If you want to add options, make sure your activity isn\'t open for enrollment right away'))
+    enrollment_end = models.DateTimeField(blank=True, null=True, verbose_name=_l('enrollment end'))
     maximum = models.PositiveIntegerField(blank=True, null=True)
-    waiting_list_locked = models.BooleanField(default=False, verbose_name=_('Lock waiting list'))
+    waiting_list_locked = models.BooleanField(default=False, verbose_name=_l('Lock waiting list'))
 
     photos = models.ManyToManyField(Attachment, blank=True, related_name='foto_set')
     components = models.ManyToManyField('self', blank=True)
 
-    price = models.DecimalField(default="0.00", max_digits=8, decimal_places=2, verbose_name=_('price'))
-    can_unenroll = models.BooleanField(default=True, verbose_name=_('can unenroll'))
+    price = models.DecimalField(default="0.00", max_digits=8, decimal_places=2, verbose_name=_l('price'))
+    can_unenroll = models.BooleanField(default=True, verbose_name=_l('can unenroll'))
 
-    image_icon = models.ImageField(upload_to='activities/icon/', max_length=255, null=True, blank=True, verbose_name=_('icon'), help_text=_('Image of 175 by 275 pixels.'))
+    image_icon = models.ImageField(upload_to='activities/icon/', max_length=255, null=True, blank=True, verbose_name=_l('icon'), help_text=_l('Image of 175 by 275 pixels.'))
 
-    facebook_event_id = models.CharField(max_length=150, blank=True, help_text=_("Facebook event id, numerical value in the facebook event url."))
+    facebook_event_id = models.CharField(max_length=150, blank=True, help_text=_l("Facebook event id, numerical value in the facebook event url."))
 
     activity_label = models.ForeignKey(ActivityLabel, on_delete=models.PROTECT)
 
@@ -79,8 +79,8 @@ class Activity(Event):
 
     class Meta:
         ordering = ['begin']
-        verbose_name = _('Activities')
-        verbose_name_plural = _('Activities')
+        verbose_name = _l('Activities')
+        verbose_name_plural = _l('Activities')
 
     def __str__(self):
         return self.summary
@@ -110,10 +110,10 @@ class Activity(Event):
 
         if self.enrollment:
             if self.enrollment_begin is None:
-                raise ValidationError(_('There is no enrollment start date entered.'))
+                raise ValidationError(_l('There is no enrollment start date entered.'))
 
             if self.enrollment_end is None:
-                raise ValidationError(_('There is no enrollment end date entered.'))
+                raise ValidationError(_l('There is no enrollment end date entered.'))
 
     def get_absolute_url(self):
         return reverse('activities:activity', args=[self.id])
@@ -216,14 +216,14 @@ class Activity(Event):
 
 class Enrollmentoption(models.Model):
     activity = models.ForeignKey(Activity, on_delete=models.CASCADE)
-    title = models.CharField(max_length=250, verbose_name=_('Title'))
+    title = models.CharField(max_length=250, verbose_name=_l('Title'))
     content_type = models.ForeignKey(ContentType, on_delete=models.PROTECT)
 
     objects = SubclassManager()
 
     class Meta:
-        verbose_name = _('Enrollment option')
-        verbose_name_plural = _('Enrollment options')
+        verbose_name = _l('Enrollment option')
+        verbose_name_plural = _l('Enrollment options')
 
     def __str__(self):
         return '%s (%s)' % (self.title, self.content_type)
@@ -264,7 +264,7 @@ class EnrollmentoptionQuestion(Enrollmentoption):
     Standard option where a question can be filled in, mandatory or not.
     """
 
-    required = models.BooleanField(default=True, verbose_name=_('Required'))
+    required = models.BooleanField(default=True, verbose_name=_l('Required'))
     objects = SubclassManager()
 
 
@@ -277,8 +277,8 @@ class EnrollmentoptionCheckbox(Enrollmentoption):
     price_extra     -- Defines the extra costs (or discount)
     """
 
-    price_extra = models.DecimalField(max_digits=8, decimal_places=2, verbose_name=_('Price extra'), default=0)
-    maximum = models.IntegerField(verbose_name=_("Maximum limit of selections"), help_text=_("Set as 0 for unlimited"), default=0)
+    price_extra = models.DecimalField(max_digits=8, decimal_places=2, verbose_name=_l('Price extra'), default=0)
+    maximum = models.IntegerField(verbose_name=_l("Maximum limit of selections"), help_text=_l("Set as 0 for unlimited"), default=0)
     objects = SubclassManager()
 
     def has_extra_costs(self):
@@ -303,9 +303,9 @@ class EnrollmentoptionNumeric(Enrollmentoption):
     price_extra     -- Defines the extra costs (or discount)
     """
 
-    price_extra = models.DecimalField(max_digits=8, decimal_places=2, verbose_name=_('Price extra'), default=0)
-    maximum = models.IntegerField(verbose_name=_("Maximum limit of selections"), help_text=_("Set as 0 for unlimited"), default=0)
-    maximum_per_person = models.IntegerField(verbose_name=_("Maximum per person"), help_text=_("Set as 0 for unlimited"), default=0)
+    price_extra = models.DecimalField(max_digits=8, decimal_places=2, verbose_name=_l('Price extra'), default=0)
+    maximum = models.IntegerField(verbose_name=_l("Maximum limit of selections"), help_text=_l("Set as 0 for unlimited"), default=0)
+    maximum_per_person = models.IntegerField(verbose_name=_l("Maximum per person"), help_text=_l("Set as 0 for unlimited"), default=0)
     objects = SubclassManager()
 
     def has_extra_costs(self):
@@ -340,7 +340,7 @@ class SelectboxOption(models.Model):
     """
 
     text = models.CharField(max_length=250)
-    price_extra = models.DecimalField(max_digits=8, decimal_places=2, verbose_name=_('Price extra'), default=0)
+    price_extra = models.DecimalField(max_digits=8, decimal_places=2, verbose_name=_l('Price extra'), default=0)
 
     selection_option = models.ForeignKey(EnrollmentoptionSelectbox, on_delete=models.CASCADE)
 
@@ -353,8 +353,8 @@ class EnrollmentoptionAnswer(models.Model):
     objects = SubclassManager()
 
     class Meta:
-        verbose_name = _('Answer to enrollment option')
-        verbose_name_plural = _('Anwers to enrollment option')
+        verbose_name = _l('Answer to enrollment option')
+        verbose_name_plural = _l('Anwers to enrollment option')
 
     @property
     def display_answer(self):
@@ -399,7 +399,7 @@ class EnrollmentoptionAnswer(models.Model):
 
 
 class EnrollmentoptionQuestionAnswer(EnrollmentoptionAnswer):
-    answer = models.CharField(max_length=250, blank=True, verbose_name=_('Respons'))
+    answer = models.CharField(max_length=250, blank=True, verbose_name=_l('Respons'))
     objects = SubclassManager()
 
     @property
@@ -408,16 +408,16 @@ class EnrollmentoptionQuestionAnswer(EnrollmentoptionAnswer):
 
     def clean(self):
         if self.enrollmentoption.enrollmentoptionquestion.required and len(self.answer) == 0:
-            raise ValidationError(_('A response is required'))
+            raise ValidationError(_l('A response is required'))
 
 
 class EnrollmentoptionCheckboxAnswer(EnrollmentoptionAnswer):
-    answer = models.BooleanField(default=False, verbose_name=_('Respons'))
+    answer = models.BooleanField(default=False, verbose_name=_l('Respons'))
     objects = SubclassManager()
 
     @property
     def display_answer(self):
-        return _("Yes") if self.answer else _("No")
+        return _l("Yes") if self.answer else _l("No")
 
     def get_price_extra(self):
         if self.answer:
@@ -427,7 +427,7 @@ class EnrollmentoptionCheckboxAnswer(EnrollmentoptionAnswer):
 
 
 class EnrollmentoptionNumericAnswer(EnrollmentoptionAnswer):
-    answer = models.IntegerField(default=0, verbose_name=_('Respons'), validators=[MinValueValidator(0)])
+    answer = models.IntegerField(default=0, verbose_name=_l('Respons'), validators=[MinValueValidator(0)])
     objects = SubclassManager()
 
     @property
@@ -439,12 +439,12 @@ class EnrollmentoptionNumericAnswer(EnrollmentoptionAnswer):
 
 
 class EnrollmentoptionSelectboxAnswer(EnrollmentoptionAnswer):
-    answer = models.ForeignKey(SelectboxOption, verbose_name=_('Respons'), on_delete=models.CASCADE)
+    answer = models.ForeignKey(SelectboxOption, verbose_name=_l('Respons'), on_delete=models.CASCADE)
     objects = SubclassManager()
 
     @property
     def display_answer(self):
-        return self.answer or _("(none)")
+        return self.answer or _l("(none)")
 
     def get_price_extra(self):
         return self.answer.price_extra
@@ -460,11 +460,11 @@ class Restaurant(models.Model):
 
 
 class Dish(models.Model):
-    restaurant = models.ForeignKey(Restaurant, on_delete=models.PROTECT, verbose_name=_('Restaurant'))
-    name = models.CharField(max_length=64, verbose_name=_('Name'))
-    price = models.DecimalField(max_digits=8, decimal_places=2, verbose_name=_('Price'))
-    available = models.BooleanField(default=True, verbose_name=_('Available'))
-    allergens = models.TextField(verbose_name=_('Allergens'), default=_('No information available'), blank=True)
+    restaurant = models.ForeignKey(Restaurant, on_delete=models.PROTECT, verbose_name=_l('Restaurant'))
+    name = models.CharField(max_length=64, verbose_name=_l('Name'))
+    price = models.DecimalField(max_digits=8, decimal_places=2, verbose_name=_l('Price'))
+    available = models.BooleanField(default=True, verbose_name=_l('Available'))
+    allergens = models.TextField(verbose_name=_l('Allergens'), default=_l('No information available'), blank=True)
 
     def __str__(self):
         if self.available:
@@ -474,8 +474,8 @@ class Dish(models.Model):
 
 
 class EnrollmentoptionFood(Enrollmentoption):
-    required = models.BooleanField(default=True, verbose_name=_('Required'))
-    restaurant = models.ForeignKey(Restaurant, on_delete=models.PROTECT, verbose_name=_('Restaurant'))
+    required = models.BooleanField(default=True, verbose_name=_l('Required'))
+    restaurant = models.ForeignKey(Restaurant, on_delete=models.PROTECT, verbose_name=_l('Restaurant'))
 
     def has_extra_costs(self):
         return any([bool(dishprice.price) for dishprice in self.dishprice_set.all()])
@@ -489,7 +489,7 @@ class DishPriceManager(models.Manager):
 class DishPrice(models.Model):
     dish = models.ForeignKey(Dish, on_delete=models.PROTECT)
     price = models.DecimalField(max_digits=8, decimal_places=2)
-    question = models.ForeignKey(EnrollmentoptionFood, verbose_name=_('Enrollment optionquestion'), on_delete=models.CASCADE)
+    question = models.ForeignKey(EnrollmentoptionFood, verbose_name=_l('Enrollment optionquestion'), on_delete=models.CASCADE)
 
     # Hide unavailable options by default
     objects = DishPriceManager()
@@ -500,7 +500,7 @@ class DishPrice(models.Model):
 
 
 class EnrollmentoptionFoodAnswer(EnrollmentoptionAnswer):
-    dishprice = models.ForeignKey(DishPrice, null=True, blank=True, verbose_name=_('Dish cost'), on_delete=models.PROTECT)
+    dishprice = models.ForeignKey(DishPrice, null=True, blank=True, verbose_name=_l('Dish cost'), on_delete=models.PROTECT)
 
     @property
     def answer(self):
@@ -508,7 +508,7 @@ class EnrollmentoptionFoodAnswer(EnrollmentoptionAnswer):
 
     @property
     def display_answer(self):
-        return self.answer or _("(none)")
+        return self.answer or _l("(none)")
 
     def get_price_extra(self):
         return self.dishprice.price if self.dishprice else super(EnrollmentoptionFoodAnswer, self).get_price_extra()
@@ -534,22 +534,22 @@ pre_save.connect(send_discord_presave, sender=Activity)
 
 class EventDeskRegistrationMessage(models.Model):
     class EventRegistrationStates(models.TextChoices):
-        NEW = 'NEW', _("Registered")
-        ACCEPTED = 'ACCEPTED', _("Accepted")
-        UNKOWN = 'UNKNOWN', _("Unknown")
+        NEW = 'NEW', _l("Registered")
+        ACCEPTED = 'ACCEPTED', _l("Accepted")
+        UNKOWN = 'UNKNOWN', _l("Unknown")
 
-    message_id = models.CharField(verbose_name=_("E-mail message ID"), unique=True, max_length=191)
-    message_date = models.DateTimeField(verbose_name=_("E-mail message timestamp"))
+    message_id = models.CharField(verbose_name=_l("E-mail message ID"), unique=True, max_length=191)
+    message_date = models.DateTimeField(verbose_name=_l("E-mail message timestamp"))
     activity = models.ForeignKey(to=Activity, blank=True, null=True, on_delete=models.SET_NULL)
-    state = models.CharField(verbose_name=_("New state of the event registration"),
+    state = models.CharField(verbose_name=_l("New state of the event registration"),
                              choices=EventRegistrationStates.choices, max_length=191)
-    requester = models.CharField(verbose_name=_("Person that requested the registration as stated in the e-mail"),
+    requester = models.CharField(verbose_name=_l("Person that requested the registration as stated in the e-mail"),
                                  max_length=191)
-    event_name = models.CharField(verbose_name=_("Name of the event as stated in the e-mail"), max_length=191)
-    event_start = models.CharField(verbose_name=_("Start date/time of the event as stated in the e-mail"), max_length=191)
-    event_end = models.CharField(verbose_name=_("End date/time of the event as stated in the e-mail"), max_length=191)
-    event_location = models.CharField(verbose_name=_("Location of the event as stated in the e-mail"), max_length=191)
-    match_ratio = models.DecimalField(verbose_name=_("Percentage certainty of match with activity."), decimal_places=3,
+    event_name = models.CharField(verbose_name=_l("Name of the event as stated in the e-mail"), max_length=191)
+    event_start = models.CharField(verbose_name=_l("Start date/time of the event as stated in the e-mail"), max_length=191)
+    event_end = models.CharField(verbose_name=_l("End date/time of the event as stated in the e-mail"), max_length=191)
+    event_location = models.CharField(verbose_name=_l("Location of the event as stated in the e-mail"), max_length=191)
+    match_ratio = models.DecimalField(verbose_name=_l("Percentage certainty of match with activity."), decimal_places=3,
                                       max_digits=6, blank=True, null=True)
 
     class Meta:
@@ -587,9 +587,9 @@ class EventDeskRegistrationMessage(models.Model):
 
     def get_match_ratio_display(self):
         if self.match_ratio is None or self.match_ratio == -1:
-            return _("n/a")
+            return _l("n/a")
         else:
-            return _("{0:.1f}% certain").format(self.match_ratio * 100)
+            return _l("{0:.1f}% certain").format(self.match_ratio * 100)
 
     def ratio_ok(self):
         if self.match_ratio is None or self.match_ratio == -1:

--- a/amelie/api/authentication.py
+++ b/amelie/api/authentication.py
@@ -1,6 +1,6 @@
 from typing import Union, List, Dict
 
-from django.utils.translation import gettext
+from django.utils.translation import gettext as _
 from oauth2_provider.models import AccessToken
 
 from amelie.api.decorators import authentication_optional, authentication_required
@@ -117,7 +117,7 @@ def get_authenticated_apps(**kwargs) -> Union[List[Dict], None]:
         for access_token in person.user.oauth2_provider_accesstoken.order_by('-expires').all():
             translated_scopes = {}
             for s, d in access_token.scopes.items():
-                translated_scopes[s] = gettext(d)
+                translated_scopes[s] = _(d)
 
             result.append({
                 "applicationName": access_token.application.name,

--- a/amelie/api/models.py
+++ b/amelie/api/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import get_language, gettext_lazy as _
+from django.utils.translation import get_language, gettext_lazy as _l
 
 from amelie.members.models import Person
 
@@ -16,8 +16,8 @@ class PushNotification(models.Model):
     recipients = models.ManyToManyField(Person, blank=True)
 
     class Meta:
-        verbose_name = _('Push Notification')
-        verbose_name_plural = _('Push Notifications')
+        verbose_name = _l('Push Notification')
+        verbose_name_plural = _l('Push Notifications')
 
     def __str__(self):
         return '%s' % self.title

--- a/amelie/blame/templatetags/blame_tags.py
+++ b/amelie/blame/templatetags/blame_tags.py
@@ -4,14 +4,14 @@ from difflib import unified_diff
 from auditlog.models import LogEntry
 from django import template
 from django.utils.encoding import smart_str
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 register = template.Library()
 
 
 @register.filter()
 def action_string(obj):
-    return _(LogEntry.Action.choices[obj.action][1])
+    return _l(LogEntry.Action.choices[obj.action][1])
 
 
 @register.filter()
@@ -41,7 +41,7 @@ def get_url(obj):
 @register.filter()
 def diff_string(obj):
     if obj.action == 2:  # deleted
-        return '<p>{}</p>'.format(_("This object has been removed."))
+        return '<p>{}</p>'.format(_l("This object has been removed."))
     changes = json.loads(obj.changes)
     changes_concat = []
     for i, field in enumerate(sorted(changes), 1):
@@ -58,7 +58,7 @@ def diff_string(obj):
 @register.filter()
 def changes_list(obj):
     if obj.action == 2:  # deleted
-        return '<p>{}</p>'.format(_("This object has been removed."))
+        return '<p>{}</p>'.format(_l("This object has been removed."))
 
     changes = obj.changes_dict
     append = ""
@@ -69,7 +69,7 @@ def changes_list(obj):
 
     if len(changes) > changes_to_show:
         more_changes = len(changes) - changes_to_show
-        append = "<p>{}</p>".format(_("And {} other changes".format(more_changes)))
+        append = "<p>{}</p>".format(_l("And {} other changes".format(more_changes)))
         changes = changes[:changes_to_show]
 
     separator = smart_str(' \u2192 ')

--- a/amelie/calendar/models.py
+++ b/amelie/calendar/models.py
@@ -8,7 +8,7 @@ from django.db import models
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 from django.utils.translation import get_language
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.files.models import Attachment
 from amelie.calendar.managers import EventManager
@@ -19,33 +19,33 @@ from amelie.personal_tab.models import ActivityTransaction
 
 class Participation(models.Model):
     class PaymentMethodChoices(models.TextChoices):
-        NONE = '-', _('No payment')
-        CASH = 'C', _('Cash at the board/committee')
-        AUTHORIZATION = 'M', _('Mandate')
+        NONE = '-', _l('No payment')
+        CASH = 'C', _l('Cash at the board/committee')
+        AUTHORIZATION = 'M', _l('Mandate')
 
-    person = models.ForeignKey(Person, verbose_name=_('Person'), on_delete=models.PROTECT)
-    event = models.ForeignKey('Event', verbose_name=_('Activities'), on_delete=models.PROTECT)
-    remark = models.TextField(blank=True, verbose_name=_('Remarks'))
+    person = models.ForeignKey(Person, verbose_name=_l('Person'), on_delete=models.PROTECT)
+    event = models.ForeignKey('Event', verbose_name=_l('Activities'), on_delete=models.PROTECT)
+    remark = models.TextField(blank=True, verbose_name=_l('Remarks'))
 
-    payment_method = models.CharField(max_length=1, choices=PaymentMethodChoices.choices, verbose_name=_('Method of payment'))
-    cash_payment_made = models.BooleanField(verbose_name=_("Cash payment made"), default=False)
-    waiting_list = models.BooleanField(verbose_name=_("On waiting list"), default=False)
+    payment_method = models.CharField(max_length=1, choices=PaymentMethodChoices.choices, verbose_name=_l('Method of payment'))
+    cash_payment_made = models.BooleanField(verbose_name=_l("Cash payment made"), default=False)
+    waiting_list = models.BooleanField(verbose_name=_l("On waiting list"), default=False)
 
-    added_on = models.DateTimeField(verbose_name=_('Added on'), auto_now_add=True, null=True, blank=True)
+    added_on = models.DateTimeField(verbose_name=_l('Added on'), auto_now_add=True, null=True, blank=True)
 
     # '+' related name makes sure no backwards reference is created in Person
-    added_by = models.ForeignKey(Person, blank=True, null=True, related_name="+", verbose_name=_('Added by'), on_delete=models.PROTECT)
+    added_by = models.ForeignKey(Person, blank=True, null=True, related_name="+", verbose_name=_l('Added by'), on_delete=models.PROTECT)
 
     class Meta:
         unique_together = [['person', 'event']]
-        verbose_name = _('Participation')
-        verbose_name_plural = _("Participations")
+        verbose_name = _l('Participation')
+        verbose_name_plural = _l("Participations")
 
     def __str__(self):
         if hasattr(self, 'event'):
             return '(%s -> %s)' % (self.person, self.event)
         else:
-            return '(%s -> %s)' % (self.person, _('deleted activity'))
+            return '(%s -> %s)' % (self.person, _l('deleted activity'))
 
     def has_paid(self):
         return not (self.payment_method == Participation.PaymentMethodChoices.CASH and self.cash_payment_made == False)
@@ -85,38 +85,38 @@ class Event(models.Model):
     """
     Activity/Event that can be transformed into <x>Calendar format.
     """
-    begin = models.DateTimeField(verbose_name=_('Starts'))
-    end = models.DateTimeField(verbose_name=_('Ends'))
-    entire_day = models.BooleanField(default=False, verbose_name=_('All dag'))
+    begin = models.DateTimeField(verbose_name=_l('Starts'))
+    end = models.DateTimeField(verbose_name=_l('Ends'))
+    entire_day = models.BooleanField(default=False, verbose_name=_l('All dag'))
 
-    summary_nl = models.CharField(max_length=250, verbose_name=_('Summary'))
-    summary_en = models.CharField(max_length=250, blank=True, null=True, verbose_name=_("Summary (en)"))
+    summary_nl = models.CharField(max_length=250, verbose_name=_l('Summary'))
+    summary_en = models.CharField(max_length=250, blank=True, null=True, verbose_name=_l("Summary (en)"))
 
-    promo_nl = models.TextField(blank=True, verbose_name=_('Short promotional message'),
-        help_text=_('This text can be used by the board for promotion, for example on our socials or in our weekmail. '
+    promo_nl = models.TextField(blank=True, verbose_name=_l('Short promotional message'),
+        help_text=_l('This text can be used by the board for promotion, for example on our socials or in our weekmail. '
                     'Let it be a teaser, so people would want to read your full activity description.'))
-    promo_en = models.TextField(blank=True, verbose_name=_('Short promotional message'),
-        help_text=_(
+    promo_en = models.TextField(blank=True, verbose_name=_l('Short promotional message'),
+        help_text=_l(
             'This text can be used by the board for promotion, for example on our socials or in our weekmail. '
             'Let it be a teaser, so people would want to read your full activity description.'))
 
-    description_nl = models.TextField(blank=True, verbose_name=_('Description'))
-    description_en = models.TextField(blank=True, null=True, verbose_name=_("Description (en)"))
+    description_nl = models.TextField(blank=True, verbose_name=_l('Description'))
+    description_en = models.TextField(blank=True, null=True, verbose_name=_l("Description (en)"))
 
-    organizer = models.ForeignKey(Committee, verbose_name=_('Organizer'), on_delete=models.PROTECT)
-    location = models.CharField(max_length=200, blank=True, verbose_name=_('Location'))
+    organizer = models.ForeignKey(Committee, verbose_name=_l('Organizer'), on_delete=models.PROTECT)
+    location = models.CharField(max_length=200, blank=True, verbose_name=_l('Location'))
     participants = models.ManyToManyField(Person, through=Participation, blank=True, through_fields=('event', 'person'),
-                                          verbose_name=_('Participants'))
-    public = models.BooleanField(default=True, verbose_name=_('Public'))
-    attachments = models.ManyToManyField(Attachment, blank=True, verbose_name=_('Attachments'))
-    dutch_activity = models.BooleanField(default=False, verbose_name=_('Dutch-only'))
+                                          verbose_name=_l('Participants'))
+    public = models.BooleanField(default=True, verbose_name=_l('Public'))
+    attachments = models.ManyToManyField(Attachment, blank=True, verbose_name=_l('Attachments'))
+    dutch_activity = models.BooleanField(default=False, verbose_name=_l('Dutch-only'))
 
-    callback_url = models.CharField(blank=True, verbose_name=_('Callback URL'), max_length=255, validators=[
-        RegexValidator(regex='^https://.*', message=_('URL has to start with https://')), URLValidator()])
+    callback_url = models.CharField(blank=True, verbose_name=_l('Callback URL'), max_length=255, validators=[
+        RegexValidator(regex='^https://.*', message=_l('URL has to start with https://')), URLValidator()])
     callback_secret_key = models.CharField(blank=True, default=_generate_callback_secret_key, max_length=255)
 
-    cancelled = models.BooleanField(default=False, verbose_name=_('Cancel event'),
-                                    help_text=_('Whether this event is cancelled, only cancel when needed. Participants will receive an email notification!'))
+    cancelled = models.BooleanField(default=False, verbose_name=_l('Cancel event'),
+                                    help_text=_l('Whether this event is cancelled, only cancel when needed. Participants will receive an email notification!'))
 
     update_count = models.PositiveIntegerField(default=0)
 
@@ -124,8 +124,8 @@ class Event(models.Model):
 
     class Meta:
         ordering = ['begin']
-        verbose_name = _('Activities')
-        verbose_name_plural = _('Activities')
+        verbose_name = _l('Activities')
+        verbose_name_plural = _l('Activities')
 
     def as_leaf_class(self):
         """
@@ -187,7 +187,7 @@ class Event(models.Model):
         if self.begin is not None and self.end is not None:
             if self.begin >= self.end:
                 raise ValidationError(
-                    {"begin": [_('Start may not be after of simultaneous to end.')]})
+                    {"begin": [_l('Start may not be after of simultaneous to end.')]})
 
     def save(self, *args, **kwargs):
         self.update_count += 1

--- a/amelie/calendar/views.py
+++ b/amelie/calendar/views.py
@@ -1,7 +1,7 @@
 from django.contrib import messages
 from django.shortcuts import get_object_or_404, redirect
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _l
 from django.views.generic import TemplateView
 
 from amelie.calendar.models import Participation
@@ -21,11 +21,11 @@ class PayParticipationView(RequireBoardMixin, TemplateView):
         participation = get_object_or_404(Participation, pk=self.kwargs['pk'])
         if 'yes' in request.POST:
             participation.cash_payment_made = True
-            remark = _(
+            remark = _l(
                 f"Payment registered on {timezone.now().strftime('%d-%m-%Y')} by {request.user.person.incomplete_name()}")
             participation.remark += f" {remark}"
             participation.save()
-            messages.success(request, _("Cash payment registered!"))
+            messages.success(request, _l("Cash payment registered!"))
         return redirect('activities:activity', participation.event_id)
 
 

--- a/amelie/claudia/claudia_views.py
+++ b/amelie/claudia/claudia_views.py
@@ -6,7 +6,7 @@ from django.urls import reverse_lazy
 from django.views.generic import ListView, DetailView, View, TemplateView
 from django.views.generic.edit import UpdateView, CreateView, DeleteView, FormView
 from django.views.generic.detail import SingleObjectMixin
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _l
 
 from amelie.settings import SYSADMINS_ABBR
 from amelie.tools.mixins import RequireCommitteeMixin, RequireStrictCommitteeMixin
@@ -142,7 +142,7 @@ class AddToMappingView(RequireCommitteeMixin, View):
             # If the member is a Mapping, add the mapping to the group
             if isinstance(self.member, Mapping):
                 if self.group.is_shareddrive() and len(self.group.members()) >= 99:
-                    raise ValueError(_("A Shared Drive can have a maximum of 99 members."))
+                    raise ValueError(_l("A Shared Drive can have a maximum of 99 members."))
                 Membership(member=self.member, group=self.group, ad=True, mail=True, description='').save()
 
             else:
@@ -413,7 +413,7 @@ class PersonalAliasRemoveView(RequireStrictCommitteeMixin, DeleteView):
     template_name = "claudia/extrapersonalalias_delete.html"
 
     def get_delete_message(self):
-        return _('Alias %(object)s has been removed' % {'object': self.get_object()})
+        return _l('Alias %(object)s has been removed' % {'object': self.get_object()})
 
     def get_success_url(self):
         pa = get_object_or_404(ExtraPersonalAlias, pk=self.kwargs['pk'])

--- a/amelie/claudia/forms.py
+++ b/amelie/claudia/forms.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError
 from django.forms import widgets
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 from urllib.parse import urljoin
 
 from amelie.claudia.models import Mapping, AliasGroup, ExtraPersonalAliasEmailValidator, ExtraPersonalAlias
@@ -16,17 +16,17 @@ from amelie.members.models import Person
 
 
 class SearchMappingForm(forms.Form):
-    search = forms.CharField(required=False, label=_('Search'))
-    include_inactive = forms.BooleanField(required=False, initial=False, label=_('Also inactive mappings'))
+    search = forms.CharField(required=False, label=_l('Search'))
+    include_inactive = forms.BooleanField(required=False, initial=False, label=_l('Also inactive mappings'))
     types = forms.MultipleChoiceField(required=False, choices=sorted([(t, t) for t in Mapping.RELATED_CLASSES]),
-                                      widget=forms.CheckboxSelectMultiple, label=_('Types'))
+                                      widget=forms.CheckboxSelectMultiple, label=_l('Types'))
 
 
 class AccountActivateForm(forms.Form):
-    account_name = forms.CharField(max_length=50, label=_('Account name'))
-    current_password = forms.CharField(widget=widgets.PasswordInput, label=_('Current password'))
-    new_password = forms.CharField(widget=widgets.PasswordInput, min_length=8, label=_('New password'))
-    new_password2 = forms.CharField(widget=widgets.PasswordInput, min_length=8, label=_('Repeat new password'))
+    account_name = forms.CharField(max_length=50, label=_l('Account name'))
+    current_password = forms.CharField(widget=widgets.PasswordInput, label=_l('Current password'))
+    new_password = forms.CharField(widget=widgets.PasswordInput, min_length=8, label=_l('New password'))
+    new_password2 = forms.CharField(widget=widgets.PasswordInput, min_length=8, label=_l('Repeat new password'))
 
     def clean(self):
         cleaned_data = super(AccountActivateForm, self).clean()
@@ -35,16 +35,16 @@ class AccountActivateForm(forms.Form):
         new_pw2 = cleaned_data.get("new_password2")
 
         if current_pw and new_pw and current_pw == new_pw:
-            self.add_error("new_password", _("New password must differ from present password"))
+            self.add_error("new_password", _l("New password must differ from present password"))
 
         if new_pw and new_pw2 and new_pw != new_pw2:
-            self.add_error("new_password2", _("The new passwords do not match"))
+            self.add_error("new_password2", _l("The new passwords do not match"))
 
 
 class AccountPasswordForm(forms.Form):
-    current_password = forms.CharField(widget=widgets.PasswordInput, label=_('Current password'))
-    new_password = forms.CharField(widget=widgets.PasswordInput, min_length=8, label=_('New password'))
-    new_password2 = forms.CharField(widget=widgets.PasswordInput, min_length=8, label=_('Repeat new password'))
+    current_password = forms.CharField(widget=widgets.PasswordInput, label=_l('Current password'))
+    new_password = forms.CharField(widget=widgets.PasswordInput, min_length=8, label=_l('New password'))
+    new_password2 = forms.CharField(widget=widgets.PasswordInput, min_length=8, label=_l('Repeat new password'))
 
     def clean(self):
         cleaned_data = super(AccountPasswordForm, self).clean()
@@ -53,21 +53,21 @@ class AccountPasswordForm(forms.Form):
         new_pw2 = cleaned_data.get("new_password2")
 
         if current_pw and new_pw and current_pw == new_pw:
-            self.add_error("new_password", _("New password must differ from present password"))
+            self.add_error("new_password", _l("New password must differ from present password"))
 
         if new_pw and new_pw2 and new_pw != new_pw2:
-            self.add_error("new_password2", _("The new passwords do not match"))
+            self.add_error("new_password2", _l("The new passwords do not match"))
 
 
 class AccountPasswordResetForm(forms.Form):
-    account_name = forms.CharField(max_length=50, label=_('Account name'))
+    account_name = forms.CharField(max_length=50, label=_l('Account name'))
 
     def clean(self):
         cleaned_data = super(AccountPasswordResetForm, self).clean()
         try:
             Person.objects.get(account_name=cleaned_data.get("account_name"))
         except Person.DoesNotExist:
-            self.add_error("account_name", _("There is no account with that name."))
+            self.add_error("account_name", _l("There is no account with that name."))
 
     def send_email(self):
         person = Person.objects.get(account_name=self.cleaned_data.get("account_name"))
@@ -106,8 +106,8 @@ class AccountPasswordResetForm(forms.Form):
 
 
 class AccountPasswordResetLinkForm(forms.Form):
-    new_password = forms.CharField(widget=widgets.PasswordInput, min_length=8, label=_('New password'))
-    new_password2 = forms.CharField(widget=widgets.PasswordInput, min_length=8, label=_('Repeat new password'))
+    new_password = forms.CharField(widget=widgets.PasswordInput, min_length=8, label=_l('New password'))
+    new_password2 = forms.CharField(widget=widgets.PasswordInput, min_length=8, label=_l('Repeat new password'))
 
     def clean(self):
         cleaned_data = super(AccountPasswordResetLinkForm, self).clean()
@@ -115,7 +115,7 @@ class AccountPasswordResetLinkForm(forms.Form):
         new_pw2 = cleaned_data.get("new_password2")
 
         if new_pw and new_pw2 and new_pw != new_pw2:
-            self.add_error("new_password2", _("The new passwords do not match"))
+            self.add_error("new_password2", _l("The new passwords do not match"))
 
 
 class AccountConfigureForwardingForm(forms.Form):
@@ -129,7 +129,7 @@ class MailAliasForm(forms.Form):
         self.fields['alias_groups'].initial = current
 
     alias_groups = MailAliasModelMultipleChoiceField(AliasGroup.objects.filter(open_to_signup=True), required=False,
-                                                     widget=widgets.CheckboxSelectMultiple, label=_('Alias groups'))
+                                                     widget=widgets.CheckboxSelectMultiple, label=_l('Alias groups'))
 
 
 class PersonalAliasCreateForm(forms.Form):
@@ -137,5 +137,5 @@ class PersonalAliasCreateForm(forms.Form):
 
     def clean_email(self):
         if ExtraPersonalAlias.objects.filter(email=self.cleaned_data['email']).count() > 0:
-            raise ValidationError(_("This mailaddress is not unique! You might want to make a group."))
+            raise ValidationError(_l("This mailaddress is not unique! You might want to make a group."))
         return self.cleaned_data['email']

--- a/amelie/claudia/models.py
+++ b/amelie/claudia/models.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from django.core.validators import EmailValidator
 from django.db import models
 from django.db.models.signals import post_save, post_delete
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.claudia.mappable import Mappable
 from amelie.claudia.tools import strip_domains, unify_mail, verify_instance, \
@@ -33,7 +33,7 @@ class ExtraGroup(models.Model, Mappable):
     def clean(self):
         super(ExtraGroup, self).clean()
         if self.email and not any(self.email.endswith(domain) for domain in settings.IA_MAIL_DOMAIN):
-            raise ValidationError({'email': _(
+            raise ValidationError({'email': _l(
                 'If an email address for an extra group is set, then it may only point to an Inter-Actief server.'
             )})
 
@@ -43,7 +43,7 @@ class ExtraGroup(models.Model, Mappable):
             # Already in use, if it's us, then it's fine
             if len(Mapping.objects.filter(email=self.email)) > 1 or \
                 Mapping.objects.get(email=self.email).get_mapped_object() != self:
-                raise ValidationError({'email': _(
+                raise ValidationError({'email': _l(
                     'This email address is already in use by another mapping!'
                 )})
 
@@ -139,7 +139,7 @@ class ExtraPerson(models.Model, Mappable):
     def clean(self):
         super(ExtraPerson, self).clean()
         if self.email and not any(self.email.endswith(domain) for domain in settings.IA_MAIL_DOMAIN):
-            raise ValidationError({'email': _(
+            raise ValidationError({'email': _l(
                 'If an extra person has an email than the email address may only point to an Inter-Actief server.'
             )})
 
@@ -149,7 +149,7 @@ class ExtraPerson(models.Model, Mappable):
             # Already in use, if it's us, then it's fine
             if len(Mapping.objects.filter(email=self.email)) > 1 or \
                 Mapping.objects.get(email=self.email).get_mapped_object() != self:
-                raise ValidationError({'email': _(
+                raise ValidationError({'email': _l(
                     'This email address is already in use by another mapping!'
                 )})
 
@@ -166,7 +166,7 @@ class AliasGroup(models.Model, Mappable):
     active = models.BooleanField(default=False)
     email = models.EmailField(unique=True, blank=True)
     description = models.TextField(blank=True)
-    open_to_signup = models.BooleanField(default=False, verbose_name=_("Open to sign up for members"), help_text=_("Note: Description becomes public"))
+    open_to_signup = models.BooleanField(default=False, verbose_name=_l("Open to sign up for members"), help_text=_l("Note: Description becomes public"))
 
     def is_active(self):
         """Is this member an active member?"""
@@ -186,7 +186,7 @@ class AliasGroup(models.Model, Mappable):
     def clean(self):
         super(AliasGroup, self).clean()
         if not any(self.email.endswith(domain) for domain in settings.IA_MAIL_DOMAIN):
-            raise ValidationError({'email': _(
+            raise ValidationError({'email': _l(
                 'An alias group may only point to an Inter-Actief server.'
             )})
 
@@ -196,7 +196,7 @@ class AliasGroup(models.Model, Mappable):
             # Already in use, if it's us, then it's fine
             if len(Mapping.objects.filter(email=self.email)) > 1 or \
                 Mapping.objects.get(email=self.email).get_mapped_object() != self:
-                raise ValidationError({'email': _(
+                raise ValidationError({'email': _l(
                     'This email address is already in use by another mapping!'
                 )})
 
@@ -222,7 +222,7 @@ class Contact(models.Model, Mappable):
 
     def clean(self):
         if self.email and any(self.email.endswith(domain) for domain in settings.IA_MAIL_DOMAIN):
-            raise ValidationError({'email': _('A contact address is not to point to an Inter-Actief server.')})
+            raise ValidationError({'email': _l('A contact address is not to point to an Inter-Actief server.')})
 
         # Check if the email address is already in use!
         if self.email and Mapping.objects.filter(email=self.email).exists():
@@ -230,7 +230,7 @@ class Contact(models.Model, Mappable):
             # Already in use, if it's us, then it's fine
             if len(Mapping.objects.filter(email=self.email)) > 1 or Mapping.objects.get(
                 email=self.email).get_mapped_object() != self:
-                raise ValidationError({'email': _(
+                raise ValidationError({'email': _l(
                     'This email address is already in use by another mapping!'
                 )})
 
@@ -605,7 +605,7 @@ post_delete.connect(verify_instance_attr, Membership)
 
 
 class ExtraPersonalAliasEmailValidator(EmailValidator):
-    message = _("E-mail address domain part must be one of {}".format(settings.CLAUDIA_GSUITE['ALLOWED_ALIAS_DOMAINS']))
+    message = _l("E-mail address domain part must be one of {}".format(settings.CLAUDIA_GSUITE['ALLOWED_ALIAS_DOMAINS']))
     domain_allowlist = settings.CLAUDIA_GSUITE['ALLOWED_ALIAS_DOMAINS']
 
     def validate_domain_part(self, domain_part):

--- a/amelie/companies/forms.py
+++ b/amelie/companies/forms.py
@@ -3,7 +3,7 @@ from django.contrib.admin.widgets import AdminFileWidget
 from django.core.files.images import get_image_dimensions
 from django.forms import SplitDateTimeField
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.companies.models import Company, WebsiteBanner, TelevisionBanner, CompanyEvent, VivatBanner
 from amelie.style.forms import inject_style
@@ -12,21 +12,21 @@ from amelie.tools.widgets import DateTimeSelector, DateSelector
 
 
 class CompanyForm(forms.ModelForm):
-    logo = forms.FileField(label=_('Logo'), widget=AdminFileWidget)
-    app_logo = forms.FileField(label=_('App Logo'), widget=AdminFileWidget, required=False)
-    start_date = forms.DateField(widget=DateSelector, label=_('From'))
-    end_date = forms.DateField(widget=DateSelector, label=_('Until'))
+    logo = forms.FileField(label=_l('Logo'), widget=AdminFileWidget)
+    app_logo = forms.FileField(label=_l('App Logo'), widget=AdminFileWidget, required=False)
+    start_date = forms.DateField(widget=DateSelector, label=_l('From'))
+    end_date = forms.DateField(widget=DateSelector, label=_l('Until'))
     short_description_nl = forms.CharField(
         max_length=120,
-        label=_('Short description'),
-        help_text=_('This text can be laid-out in 120 characters'),
+        label=_l('Short description'),
+        help_text=_l('This text can be laid-out in 120 characters'),
         widget=forms.Textarea,
         required=False
     )
     short_description_en = forms.CharField(
         max_length=120,
-        label=_('Short description'),
-        help_text=_('This text can be laid-out in 120 characters'),
+        label=_l('Short description'),
+        help_text=_l('This text can be laid-out in 120 characters'),
         widget=forms.Textarea,
         required=False
     )
@@ -55,14 +55,14 @@ class CompanyForm(forms.ModelForm):
             min_w, min_h = 1024, 1024
 
             if w > min_w or h > min_h:
-                raise forms.ValidationError(_("The thumbnail logo's size is %(w)dpx by %(h)dpx, while the maximum allowed size is %(min_w)dpx by %(min_h)dpx.") %
+                raise forms.ValidationError(_l("The thumbnail logo's size is %(w)dpx by %(h)dpx, while the maximum allowed size is %(min_w)dpx by %(min_h)dpx.") %
                                             {'w': w, 'h': h, 'min_w': min_w, 'min_h': min_h})
 
         return app_logo
 
 
 class BannerForm(forms.ModelForm):
-    picture = forms.ImageField(label=_('Website banner'), widget=AdminFileWidget)
+    picture = forms.ImageField(label=_l('Website banner'), widget=AdminFileWidget)
     start_date = forms.DateField(widget=DateSelector)
     end_date = forms.DateField(widget=DateSelector)
 
@@ -72,7 +72,7 @@ class BannerForm(forms.ModelForm):
 
 
 class TelevisionBannerForm(forms.ModelForm):
-    picture = forms.ImageField(label=_('Television banner'), widget=AdminFileWidget)
+    picture = forms.ImageField(label=_l('Television banner'), widget=AdminFileWidget)
     start_date = forms.DateField(widget=DateSelector)
     end_date = forms.DateField(widget=DateSelector)
 
@@ -82,7 +82,7 @@ class TelevisionBannerForm(forms.ModelForm):
 
 
 class VivatBannerForm(forms.ModelForm):
-    picture = forms.FileField(label=_('Vivat banner'), widget=AdminFileWidget)
+    picture = forms.FileField(label=_l('Vivat banner'), widget=AdminFileWidget)
     start_date = forms.DateField(widget=DateSelector)
     end_date = forms.DateField(widget=DateSelector)
 
@@ -127,17 +127,17 @@ class CompanyEventForm(EventForm):
         visible_till = data.get('visible_till', False)
 
         if not (b or (data.get('company_text', None) and data.get('company_url', None))):
-            raise forms.ValidationError({"company": [_("Company Corner company or name/website is obligatory.")]})
+            raise forms.ValidationError({"company": [_l("Company Corner company or name/website is obligatory.")]})
 
         if visible_from and visible_till and data['visible_from'] > data['visible_till']:
-            raise forms.ValidationError({"visible_from": [_(u'Activity\'s "visible from" date is later than its "visible until" date')]})
+            raise forms.ValidationError({"visible_from": [_l(u'Activity\'s "visible from" date is later than its "visible until" date')]})
 
         return data
 
 
 class StatisticsForm(forms.Form):
-    start_date = forms.SplitDateTimeField(label=_('Beginning:'), widget=DateTimeSelector, required=True)
-    end_date = forms.SplitDateTimeField(label=_('End (till)'), widget=DateTimeSelector, required=True)
+    start_date = forms.SplitDateTimeField(label=_l('Beginning:'), widget=DateTimeSelector, required=True)
+    end_date = forms.SplitDateTimeField(label=_l('End (till)'), widget=DateTimeSelector, required=True)
 
 
 inject_style(CompanyForm, CompanyEventForm, BannerForm, TelevisionBannerForm, VivatBannerForm, StatisticsForm)

--- a/amelie/companies/models.py
+++ b/amelie/companies/models.py
@@ -4,7 +4,7 @@ from django.db import models
 from django.db.models.signals import post_save
 from django.template.defaultfilters import slugify
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _, get_language
+from django.utils.translation import gettext_lazy as _l, get_language
 
 from amelie.companies.managers import CompanyManager
 from amelie.calendar.managers import EventManager
@@ -15,11 +15,11 @@ from amelie.tools.discord import send_discord
 class Company(models.Model):
     name_nl = models.CharField(
         max_length=100,
-        verbose_name=_('name')
+        verbose_name=_l('name')
     )
     name_en = models.CharField(
         max_length=100,
-        verbose_name=_('name (en)'),
+        verbose_name=_l('name (en)'),
         blank=True)
     slug = models.SlugField(
         max_length=100,
@@ -41,33 +41,33 @@ class Company(models.Model):
         null=True
     )
     profile_nl = models.TextField(
-        verbose_name=_('profile')
+        verbose_name=_l('profile')
     )
     profile_en = models.TextField(
-        verbose_name=_('profile (en)'),
+        verbose_name=_l('profile (en)'),
         blank=True
     )
     short_description_nl = models.CharField(
         max_length=120,
-        verbose_name=_('short description'),
+        verbose_name=_l('short description'),
         blank=True,
     )
     short_description_en = models.CharField(
         max_length=120,
-        verbose_name=_('short description (en)'),
+        verbose_name=_l('short description (en)'),
         blank=True
     )
     start_date = models.DateField(
-        verbose_name=_('from')
+        verbose_name=_l('from')
     )
     end_date = models.DateField(
-        verbose_name=_('until')
+        verbose_name=_l('until')
     )
 
     # For the Inter-Actief mobile application
     show_in_app = models.BooleanField(
         default=False,
-        verbose_name=_('show in app')
+        verbose_name=_l('show in app')
     )
     app_logo = models.ImageField(
         upload_to='companies/app_logos/',
@@ -87,8 +87,8 @@ class Company(models.Model):
 
     class Meta:
         ordering = ['name_nl']
-        verbose_name = _('Company')
-        verbose_name_plural = _('Companies')
+        verbose_name = _l('Company')
+        verbose_name_plural = _l('Companies')
 
     def __str__(self):
         return '%s' % self.name
@@ -102,7 +102,7 @@ class Company(models.Model):
             conflicts = conflicts.exclude(pk=self.pk)
 
         if conflicts.exists():
-            raise ValidationError({'name_nl': _("The slug for this name already exists!")})
+            raise ValidationError({'name_nl': _l("The slug for this name already exists!")})
 
     def save(self, *args, **kwargs):
         self.slug = slugify(self.name_nl)
@@ -167,15 +167,15 @@ class WebsiteBanner(BaseBanner):
 
     class Meta:
         ordering = ['-end_date']
-        verbose_name = _('Website banner')
-        verbose_name_plural = _('Website banners')
+        verbose_name = _l('Website banner')
+        verbose_name_plural = _l('Website banners')
 
 
 class TelevisionBanner(BaseBanner):
     class Meta:
         ordering = ['-end_date']
-        verbose_name = _('Television banner')
-        verbose_name_plural = _('Television banners')
+        verbose_name = _l('Television banner')
+        verbose_name_plural = _l('Television banners')
 
 
 class VivatBanner(BaseBanner):
@@ -188,8 +188,8 @@ class VivatBanner(BaseBanner):
 
     class Meta:
         ordering = ['-end_date']
-        verbose_name = _('I/O Vivat banner')
-        verbose_name_plural = _('I/O Vivat banners')
+        verbose_name = _l('I/O Vivat banner')
+        verbose_name_plural = _l('I/O Vivat banners')
 
 
 class CompanyEvent(Event):

--- a/amelie/companies/views.py
+++ b/amelie/companies/views.py
@@ -8,7 +8,7 @@ from django.db.models import Q
 from django.http import HttpResponseRedirect, HttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 from django.views.generic import FormView
 
 from amelie.companies.forms import CompanyForm, BannerForm, TelevisionBannerForm, CompanyEventForm, StatisticsForm, \
@@ -336,7 +336,7 @@ def event_old(request):
 def company_events_ics(request):
     """ Will return an ics file containing all the CompanyEvents. """
     resp = HttpResponse(content_type='text/calendar; charset=UTF-8')
-    resp.write(ical_calendar(_('Inter-Actief external activities'), CompanyEvent.objects.filter(
+    resp.write(ical_calendar(_l('Inter-Actief external activities'), CompanyEvent.objects.filter(
         begin__gte=timezone.now() - datetime.timedelta(100)).order_by('begin')))
 
     return resp
@@ -347,7 +347,7 @@ def company_event_ics(request, id):
     event = get_object_or_404(CompanyEvent, id=id)
 
     resp = HttpResponse(content_type='text/calendar; charset=UTF-8')
-    resp.write(ical_calendar(_(event.summary), [event, ]))
+    resp.write(ical_calendar(_l(event.summary), [event, ]))
 
     return resp
 

--- a/amelie/data_export/exporters/amelie.py
+++ b/amelie/data_export/exporters/amelie.py
@@ -1,7 +1,7 @@
 import os
 
 import json
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 from oauth2_provider.models import Application, AccessToken, Grant
 from zipfile import ZipFile
 
@@ -134,7 +134,7 @@ class AmelieDataExporter(DataExporter):
                 enrollment_data['event'] = "{} ({} - {})".format(enrollment.event.summary, enrollment.event.begin,
                                                                  enrollment.event.end)
             else:
-                enrollment_data['event'] = _('deleted activity')
+                enrollment_data['event'] = _l('deleted activity')
 
             for enrollment_option_answer in enrollment.enrollmentoptionanswer_set.all():
                 enrollment_data['enrollment_options'].append({

--- a/amelie/data_export/forms.py
+++ b/amelie/data_export/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.forms import CheckboxSelectMultiple
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.data_export.models import ApplicationStatus
 from amelie.style.forms import inject_style
@@ -9,8 +9,8 @@ from amelie.style.forms import inject_style
 class DataExportCreateForm(forms.Form):
     applications = forms.MultipleChoiceField(choices=ApplicationStatus.ApplicationChoices.choices,
                                              widget=CheckboxSelectMultiple,
-                                             label=_("For which things do you want to request a data export?"),
-                                             help_text=_("Which applications, files or other data this data export has to contain."),
+                                             label=_l("For which things do you want to request a data export?"),
+                                             help_text=_l("Which applications, files or other data this data export has to contain."),
                                              # Turn on all options by default.
                                              initial=[c for c in ApplicationStatus.ApplicationChoices.values
                                                       if ApplicationStatus.APPLICATION_MODELS[c].default_enabled])

--- a/amelie/data_export/models.py
+++ b/amelie/data_export/models.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 from django.conf import settings
 from django.db import models
 from django.urls import reverse
-from django.utils.translation import gettext_lazy as _, gettext
+from django.utils.translation import gettext_lazy as _l, gettext as _
 
 from amelie.data_export.exporters.alexia import AlexiaDataExporter
 from amelie.data_export.exporters.amelie import AmelieDataExporter
@@ -25,30 +25,30 @@ class DataExport(models.Model):
     A data export containing the data for a single person.
     """
 
-    download_code = models.CharField(max_length=50, verbose_name=_("Download code"), unique=True,
-                                     help_text=_("Code with which you can download this export."))
+    download_code = models.CharField(max_length=50, verbose_name=_l("Download code"), unique=True,
+                                     help_text=_l("Code with which you can download this export."))
 
-    person = models.OneToOneField(to=Person, verbose_name=_("Person"), null=True, on_delete=models.SET_NULL,
-                                  help_text=_("The person whose data export this is."))
+    person = models.OneToOneField(to=Person, verbose_name=_l("Person"), null=True, on_delete=models.SET_NULL,
+                                  help_text=_l("The person whose data export this is."))
 
-    filename = models.FilePathField(path=settings.DATA_EXPORT_ROOT, verbose_name=_("Filename"), null=True, blank=True,
-                                    help_text=_("The file name of the exported data."))
+    filename = models.FilePathField(path=settings.DATA_EXPORT_ROOT, verbose_name=_l("Filename"), null=True, blank=True,
+                                    help_text=_l("The file name of the exported data."))
 
-    request_timestamp = models.DateTimeField(verbose_name=_("Timestamp of request"), auto_now_add=True,
-                                             help_text=_("The time that this data export was requested."))
+    request_timestamp = models.DateTimeField(verbose_name=_l("Timestamp of request"), auto_now_add=True,
+                                             help_text=_l("The time that this data export was requested."))
 
-    complete_timestamp = models.DateTimeField(verbose_name=_("Timestamp of completion"), null=True, blank=True,
-                                              help_text=_("The time that this data export was completed."))
+    complete_timestamp = models.DateTimeField(verbose_name=_l("Timestamp of completion"), null=True, blank=True,
+                                              help_text=_l("The time that this data export was completed."))
 
-    download_count = models.IntegerField(verbose_name=_("Number of times downloaded"), default=0,
-                                         help_text=_("How many times this export has been downloaded."))
+    download_count = models.IntegerField(verbose_name=_l("Number of times downloaded"), default=0,
+                                         help_text=_l("How many times this export has been downloaded."))
 
-    is_ready = models.BooleanField(verbose_name=_("Export is complete"), default=False,
-                                   help_text=_("If this export is ready to be downloaded or not."))
+    is_ready = models.BooleanField(verbose_name=_l("Export is complete"), default=False,
+                                   help_text=_l("If this export is ready to be downloaded or not."))
 
     class Meta:
-        verbose_name = _("Data export")
-        verbose_name_plural = _("Data exports")
+        verbose_name = _l("Data export")
+        verbose_name_plural = _l("Data exports")
 
     @property
     def expires_on(self):
@@ -62,7 +62,7 @@ class DataExport(models.Model):
         return self.expires_on < timezone.now()
 
     def __str__(self):
-        return gettext("Data export of {}").format(self.person if self.person else _("<unknown>"))
+        return _("Data export of {}").format(self.person if self.person else _l("<unknown>"))
 
     def get_absolute_url(self):
         return reverse('data_export:export_details', kwargs={'slug': self.download_code})
@@ -71,19 +71,19 @@ class DataExport(models.Model):
 class ApplicationStatus(models.Model):
     # Different choices for the status field.
     class StatusChoices(models.IntegerChoices):
-        NOT_STARTED = 0, _("Not yet started")
-        RUNNING = 1, _("Busy exporting data")
-        SUCCESS = 2, _("Done exporting data")
-        ERROR = 3, _("Error during exporting")
+        NOT_STARTED = 0, _l("Not yet started")
+        RUNNING = 1, _l("Busy exporting data")
+        SUCCESS = 2, _l("Done exporting data")
+        ERROR = 3, _l("Error during exporting")
 
     # Different choices for the application to export data from.
     class ApplicationChoices(models.TextChoices):
-        AMELIE = 'AmelieDataExporter', _("Data in the Inter-/Actief/ website and the members database.")
-        AMELIE_FILES = 'AmelieFileDataExporter', _("Files you have uploaded to the Inter-/Actief/ website "
+        AMELIE = 'AmelieDataExporter', _l("Data in the Inter-/Actief/ website and the members database.")
+        AMELIE_FILES = 'AmelieFileDataExporter', _l("Files you have uploaded to the Inter-/Actief/ website "
                                                    "(warning, may be very large).")
-        ALEXIA = 'AlexiaDataExporter', _("Data from Alexia, the drink management system.")
-        GITLAB = 'GitLabDataExporter', _("Data in GitLab, the version control system.")
-        HOMEDIR = 'HomedirDataExporter', _("The home directory of your Inter-Actief active members account"
+        ALEXIA = 'AlexiaDataExporter', _l("Data from Alexia, the drink management system.")
+        GITLAB = 'GitLabDataExporter', _l("Data in GitLab, the version control system.")
+        HOMEDIR = 'HomedirDataExporter', _l("The home directory of your Inter-Actief active members account"
                                            " (warning, may be very large).")
 
     # Lookup dictionary for application choice string and the actual exporter class.
@@ -95,22 +95,22 @@ class ApplicationStatus(models.Model):
         ApplicationChoices.HOMEDIR.value: HomedirDataExporter,
     }
 
-    data_export = models.ForeignKey(to=DataExport, verbose_name=_("Data export"), on_delete=models.CASCADE,
+    data_export = models.ForeignKey(to=DataExport, verbose_name=_l("Data export"), on_delete=models.CASCADE,
                                     related_name="exported_applications",
-                                    help_text=_("Which data export this status belongs to"))
+                                    help_text=_l("Which data export this status belongs to"))
 
-    application = models.CharField(max_length=40, choices=ApplicationChoices.choices, verbose_name=_("Application"),
-                                   help_text=_("The name of the application you want to export data from."))
+    application = models.CharField(max_length=40, choices=ApplicationChoices.choices, verbose_name=_l("Application"),
+                                   help_text=_l("The name of the application you want to export data from."))
 
-    status = models.IntegerField(choices=StatusChoices.choices, verbose_name=_("Export status"), default=0,
-                                 help_text=_("The status of the export from this application."))
+    status = models.IntegerField(choices=StatusChoices.choices, verbose_name=_l("Export status"), default=0,
+                                 help_text=_l("The status of the export from this application."))
 
     class Meta:
-        verbose_name = _("Application status")
-        verbose_name_plural = _("Application statuses")
+        verbose_name = _l("Application status")
+        verbose_name_plural = _l("Application statuses")
 
     def __str__(self):
-        return gettext("Export status for {} of {} ({})").format(self.get_application_display(), self.data_export, self.get_status_display())
+        return _("Export status for {} of {} ({})").format(self.get_application_display(), self.data_export, self.get_status_display())
 
 
 @receiver(post_delete, sender=DataExport)

--- a/amelie/education/forms.py
+++ b/amelie/education/forms.py
@@ -3,7 +3,7 @@ from django import forms
 from django.conf import settings
 from django.forms import widgets
 from django.utils.encoding import force_str
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.iamailer.mailtask import MailTask, Recipient
 from amelie.style.forms import inject_style
@@ -41,18 +41,18 @@ def calc_choices():
     result = [(None, '—')]
     modules = [(module.id, module.name) for module in Module.objects.all()]
     courses = [(course.id, course.name) for course in Course.objects.all()]
-    result.append((_('Module'), tuple(modules)))
-    result.append((_('Course'), tuple(courses)))
+    result.append((_l('Module'), tuple(modules)))
+    result.append((_l('Course'), tuple(courses)))
 
     return result
 
 
 class ComplaintForm(forms.ModelForm):
     subject = forms.ChoiceField(choices=Complaint.ComplaintChoices.choices, widget=widgets.RadioSelect)
-    course = forms.ChoiceField(required=False, label=_('Course'))
-    part = forms.CharField(max_length=255, required=False, label=_('Subject'),
-                           widget=forms.TextInput(attrs={'placeholder': _('Subject')}))
-    year = forms.IntegerField(min_value=1, required=False, initial=current_academic_year_strict, label=_('Year'))
+    course = forms.ChoiceField(required=False, label=_l('Course'))
+    part = forms.CharField(max_length=255, required=False, label=_l('Subject'),
+                           widget=forms.TextInput(attrs={'placeholder': _l('Subject')}))
+    year = forms.IntegerField(min_value=1, required=False, initial=current_academic_year_strict, label=_l('Year'))
 
     def __init__(self, *args, **kwargs):
         super(ComplaintForm, self).__init__(*args, **kwargs)
@@ -69,7 +69,7 @@ class ComplaintForm(forms.ModelForm):
         course = cleaned_data.get('course', None)
         if subject == 'Grading' and not course:
             raise forms.ValidationError(
-                _('If the deadline for revision of your exam has passed, you can select a course'))
+                _l('If the deadline for revision of your exam has passed, you can select a course'))
         return BaseCourseModule.objects.get(id=course) if course else None
 
     def clean_comment(self):
@@ -78,16 +78,16 @@ class ComplaintForm(forms.ModelForm):
         summary = cleaned_data.get('summary', '')
         comment = cleaned_data.get('comment', '')
         if subject != 'Grading' and (len(summary) == 0 or len(comment) == 0):
-            raise forms.ValidationError(_('Fill in a summary and comments'))
+            raise forms.ValidationError(_l('Fill in a summary and comments'))
         return cleaned_data['comment']
 
 
 class EducationalBouquetForm(forms.Form):
-    teacher = forms.CharField(max_length=60, label=_('Teacher'))
-    course = forms.ChoiceField(label=_('Course'))
-    reason = forms.CharField(max_length=300, widget=forms.Textarea, label=_('Reason'))
-    author = forms.CharField(max_length=40, label=_('Author'))
-    email = forms.EmailField(max_length=50, label=_('E-mail'))
+    teacher = forms.CharField(max_length=60, label=_l('Teacher'))
+    course = forms.ChoiceField(label=_l('Course'))
+    reason = forms.CharField(max_length=300, widget=forms.Textarea, label=_l('Reason'))
+    author = forms.CharField(max_length=40, label=_l('Author'))
+    email = forms.EmailField(max_length=50, label=_l('E-mail'))
 
     def __init__(self, *args, **kwargs):
         super(EducationalBouquetForm, self).__init__(*args, **kwargs)
@@ -157,7 +157,7 @@ class DEAVoteForm(forms.Form):
         if not vote:
             return cleaned_data
         else:
-            raise forms.ValidationError(_('You\'ve already voted!'))
+            raise forms.ValidationError(_l('You\'ve already voted!'))
 
     def save(self, *args, **kwargs):
         self.competition = Competition.objects.get(title="Onderwijsprijs 2015")
@@ -184,7 +184,7 @@ class DEAVoteForm(forms.Form):
 
 
 class CourseForm(forms.ModelForm):
-    name = forms.CharField(max_length=200, label=_("Course name"))
+    name = forms.CharField(max_length=200, label=_l("Course name"))
     course_code = forms.IntegerField(min_value=0, max_value=2147483647)
 
     class Meta:
@@ -196,7 +196,7 @@ class CourseForm(forms.ModelForm):
 
 
 class ModuleForm(forms.ModelForm):
-    name = forms.CharField(max_length=200, label=_("Module name"))
+    name = forms.CharField(max_length=200, label=_l("Module name"))
     course_code = forms.IntegerField(min_value=0, max_value=2147483647)
 
     class Meta:
@@ -208,7 +208,7 @@ class ModuleForm(forms.ModelForm):
 
 
 class SearchSummariesForm(forms.Form):
-    filter = forms.CharField(label=_('Name of course'), required=False)
+    filter = forms.CharField(label=_l('Name of course'), required=False)
 
 
 class EducationEventForm(EventForm):

--- a/amelie/education/models.py
+++ b/amelie/education/models.py
@@ -10,7 +10,7 @@ from django.db.models.signals import post_save
 from django.template.defaultfilters import slugify
 from django.utils.encoding import force_str
 from django.utils.translation import get_language
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.iamailer.mailtask import MailTask
 from amelie.calendar.models import Event
@@ -22,13 +22,13 @@ from amelie.tools.mail import PersonRecipient
 
 
 class Category(models.Model):
-    name_nl = models.SlugField(max_length=100, verbose_name=_('Name'))
-    name_en = models.SlugField(max_length=100, verbose_name=_('Name (en)'), blank=True)
+    name_nl = models.SlugField(max_length=100, verbose_name=_l('Name'))
+    name_en = models.SlugField(max_length=100, verbose_name=_l('Name (en)'), blank=True)
 
     class Meta:
         ordering = ['name_nl']
-        verbose_name = _('Category')
-        verbose_name_plural = _('Categories')
+        verbose_name = _l('Category')
+        verbose_name_plural = _l('Categories')
 
     def __str__(self):
         return '%s' % self.name
@@ -44,19 +44,19 @@ class Category(models.Model):
 
 
 class Page(models.Model):
-    name_nl = models.CharField(max_length=100, verbose_name=_('Name'))
-    name_en = models.CharField(max_length=100, verbose_name=_('Name (en)'), blank=True)
+    name_nl = models.CharField(max_length=100, verbose_name=_l('Name'))
+    name_en = models.CharField(max_length=100, verbose_name=_l('Name (en)'), blank=True)
     slug = models.SlugField(max_length=100, editable=False)
     category = models.ForeignKey(Category, on_delete=models.PROTECT)
-    content_nl = models.TextField(verbose_name=_('Content'))
-    content_en = models.TextField(verbose_name=_('Content (en)'), blank=True)
+    content_nl = models.TextField(verbose_name=_l('Content'))
+    content_en = models.TextField(verbose_name=_l('Content (en)'), blank=True)
     last_changed = models.DateTimeField(auto_now=True)
     position = models.IntegerField(unique=True)
 
     class Meta:
         ordering = ['position']
-        verbose_name = _('Page')
-        verbose_name_plural = _("Pages")
+        verbose_name = _l('Page')
+        verbose_name_plural = _l("Pages")
 
     def __str__(self):
         return '%s' % self.name
@@ -128,25 +128,25 @@ class Period(models.Model):
     """
     Quartiles, semesters, trimesters...
     """
-    year = models.PositiveIntegerField(verbose_name=_('Year'))
-    name = models.CharField(max_length=5, verbose_name=_('Name'))
-    start = models.DateField(verbose_name=_('Starts'))
-    end = models.DateField(verbose_name=_('Ends'))
+    year = models.PositiveIntegerField(verbose_name=_l('Year'))
+    name = models.CharField(max_length=5, verbose_name=_l('Name'))
+    start = models.DateField(verbose_name=_l('Starts'))
+    end = models.DateField(verbose_name=_l('Ends'))
 
-    end_lectures = models.DateField(verbose_name=_('End of lectures'))
-    exam_enrollment_start = models.DateField(verbose_name=_('Exam enrollment starts'), null=True,
+    end_lectures = models.DateField(verbose_name=_l('End of lectures'))
+    exam_enrollment_start = models.DateField(verbose_name=_l('Exam enrollment starts'), null=True,
                                                    blank=True)
-    exam_enrollment_end = models.DateField(verbose_name=_('Exam enrollment stops'), null=True,
+    exam_enrollment_end = models.DateField(verbose_name=_l('Exam enrollment stops'), null=True,
                                                   blank=True)
-    course_enrollment_start = models.DateField(verbose_name=_('Enrollment for courses starts'), null=True, blank=True)
-    course_enrollment_end = models.DateField(verbose_name=_('Enrollment for courses stops'), null=True, blank=True)
-    books_ordering_start = models.DateField(verbose_name=_('Book order period starts'), null=True, blank=True)
-    books_ordering_end = models.DateField(verbose_name=_('Book order stops'), null=True, blank=True)
+    course_enrollment_start = models.DateField(verbose_name=_l('Enrollment for courses starts'), null=True, blank=True)
+    course_enrollment_end = models.DateField(verbose_name=_l('Enrollment for courses stops'), null=True, blank=True)
+    books_ordering_start = models.DateField(verbose_name=_l('Book order period starts'), null=True, blank=True)
+    books_ordering_end = models.DateField(verbose_name=_l('Book order stops'), null=True, blank=True)
 
     class Meta:
         ordering = ['year', 'start', '-name']
-        verbose_name = _('Part of year')
-        verbose_name_plural = _('Parts of year')
+        verbose_name = _l('Part of year')
+        verbose_name_plural = _l('Parts of year')
 
     def __str__(self):
         return '%s (%s/%s)' % (self.name, self.year, self.year+1)
@@ -156,27 +156,27 @@ class Period(models.Model):
 
         if self.start is not None and self.end is not None:
             if self.start >= self.end:
-                raise ValidationError(_('Start may not be after of simultaneous to end.'))
+                raise ValidationError(_l('Start may not be after of simultaneous to end.'))
 
         if self.exam_enrollment_start is not None and self.exam_enrollment_end is not None:
             if self.exam_enrollment_start >= self.exam_enrollment_end:
                 raise ValidationError(
-                    _('Start of enrollment term for the exams may not be after or simultaneous to the end of this term.'))
+                    _l('Start of enrollment term for the exams may not be after or simultaneous to the end of this term.'))
 
         if self.course_enrollment_start is not None and self.course_enrollment_end is not None:
             if self.course_enrollment_start >= self.course_enrollment_end:
                 raise ValidationError(
-                    _('Start of enrollment term for courses may not be after or simultaneous to the end of this term.'))
+                    _l('Start of enrollment term for courses may not be after or simultaneous to the end of this term.'))
 
         if self.books_ordering_start is not None and self.books_ordering_end is not None:
             if self.books_ordering_start >= self.books_ordering_end:
                 raise ValidationError(
-                    _('Start of the term for ordering books may not be after or simultaneous to the end of this term.'))
+                    _l('Start of the term for ordering books may not be after or simultaneous to the end of this term.'))
 
 
 class BaseCourseModule(models.Model):
-    name = models.CharField(max_length=200, verbose_name=_('Name'))
-    course_code = models.PositiveIntegerField(unique=True, verbose_name=_("Course code"),
+    name = models.CharField(max_length=200, verbose_name=_l('Name'))
+    course_code = models.PositiveIntegerField(unique=True, verbose_name=_l("Course code"),
                                               validators=[MinValueValidator(100000), MaxValueValidator(999999999)])
 
     def __str__(self):
@@ -204,8 +204,8 @@ class Module(BaseCourseModule):
 
     class Meta:
         ordering = ['name', 'course_code']
-        verbose_name = _('Module')
-        verbose_name_plural = _('Modules')
+        verbose_name = _l('Module')
+        verbose_name_plural = _l('Modules')
 
 
 class Course(BaseCourseModule):
@@ -213,12 +213,12 @@ class Course(BaseCourseModule):
     A course with a specific content
     """
     module_ptr = models.ForeignKey(Module, on_delete=models.PROTECT, related_name="courses", null=True,
-                                   verbose_name=_("Module"), blank=True)
+                                   verbose_name=_l("Module"), blank=True)
 
     class Meta:
         ordering = ['name', 'course_code']
-        verbose_name = _('Course')
-        verbose_name_plural = _('Courses')
+        verbose_name = _l('Course')
+        verbose_name_plural = _l('Courses')
 
     def get_absolute_url(self):
         return reverse('education:course', args=(), kwargs={
@@ -232,42 +232,42 @@ class Complaint(models.Model):
     General education complaint
     """
     class ComplaintChoices(models.TextChoices):
-        GRADING = 'Grading', _('Marking period expired')
-        FACILITIES = 'Facilities', _('Facilities')
-        INFORMATION = 'Information', _('Information supply')
-        INTERNATIONALIZATION = 'Internationalization', _('Internationalization')
-        OTHER = 'Other', _('Otherwise')
+        GRADING = 'Grading', _l('Marking period expired')
+        FACILITIES = 'Facilities', _l('Facilities')
+        INFORMATION = 'Information', _l('Information supply')
+        INTERNATIONALIZATION = 'Internationalization', _l('Internationalization')
+        OTHER = 'Other', _l('Otherwise')
 
     class PeriodChoices(models.TextChoices):
-        Q1 = 'Q1', _('Quarter 1')
-        Q2 = 'Q2', _('Quarter 2')
-        Q3 = 'Q3', _('Quarter 3')
-        Q4 = 'Q4', _('Quarter 4')
-        S1 = 'S1', _('Semester 1')
-        S2 = 'S2', _('Semester 2')
+        Q1 = 'Q1', _l('Quarter 1')
+        Q2 = 'Q2', _l('Quarter 2')
+        Q3 = 'Q3', _l('Quarter 3')
+        Q4 = 'Q4', _l('Quarter 4')
+        S1 = 'S1', _l('Semester 1')
+        S2 = 'S2', _l('Semester 2')
 
     published = models.DateTimeField(auto_now_add=True)
 
-    subject = models.CharField(max_length=50, choices=ComplaintChoices.choices, verbose_name=_('Subject'))
-    summary = models.CharField(max_length=100, blank=True, verbose_name=_('Summary'))
-    comment = models.TextField(verbose_name=_('Remarks'), blank=True)
+    subject = models.CharField(max_length=50, choices=ComplaintChoices.choices, verbose_name=_l('Subject'))
+    summary = models.CharField(max_length=100, blank=True, verbose_name=_l('Summary'))
+    comment = models.TextField(verbose_name=_l('Remarks'), blank=True)
 
-    reporter = models.ForeignKey(Person, editable=False, verbose_name=_('Reporter'), on_delete=models.PROTECT)
-    people = models.ManyToManyField(Person, verbose_name=_('People'), editable=False, related_name='personen')
-    public = models.BooleanField(default=False, verbose_name=_('Public'))
-    progress = models.BooleanField(default=False, verbose_name=_('Feedback on progress'))
-    anonymous = models.BooleanField(default=False, verbose_name=_('Handle anonymously'))
-    completed = models.BooleanField(default=False, verbose_name=_('Handled'))
+    reporter = models.ForeignKey(Person, editable=False, verbose_name=_l('Reporter'), on_delete=models.PROTECT)
+    people = models.ManyToManyField(Person, verbose_name=_l('People'), editable=False, related_name='personen')
+    public = models.BooleanField(default=False, verbose_name=_l('Public'))
+    progress = models.BooleanField(default=False, verbose_name=_l('Feedback on progress'))
+    anonymous = models.BooleanField(default=False, verbose_name=_l('Handle anonymously'))
+    completed = models.BooleanField(default=False, verbose_name=_l('Handled'))
 
-    course = models.ForeignKey(BaseCourseModule, null=True, blank=True, verbose_name=_('Course or module'), on_delete=models.SET_NULL)
-    part = models.CharField(max_length=255, null=True, blank=True, verbose_name=_('Subject'))
-    year = models.PositiveIntegerField(null=True, blank=True, verbose_name=_('Year'))
-    period = models.CharField(max_length=2, choices=PeriodChoices.choices, null=True, blank=True, verbose_name=_('Term'))
+    course = models.ForeignKey(BaseCourseModule, null=True, blank=True, verbose_name=_l('Course or module'), on_delete=models.SET_NULL)
+    part = models.CharField(max_length=255, null=True, blank=True, verbose_name=_l('Subject'))
+    year = models.PositiveIntegerField(null=True, blank=True, verbose_name=_l('Year'))
+    period = models.CharField(max_length=2, choices=PeriodChoices.choices, null=True, blank=True, verbose_name=_l('Term'))
 
     class Meta:
         ordering = ['-published']
-        verbose_name = _('Complaint')
-        verbose_name_plural = _('Complaints')
+        verbose_name = _l('Complaint')
+        verbose_name_plural = _l('Complaints')
 
     def __str__(self):
         return '%s (%s)' % (self.course, self.subject)
@@ -282,18 +282,18 @@ class ComplaintComment(models.Model):
     """
 
     published = models.DateTimeField(editable=False, auto_now_add=True)
-    public = models.BooleanField(verbose_name=_('Public'), default=True)
-    complaint = models.ForeignKey(Complaint, editable=False, verbose_name=_('Complaint'), on_delete=models.CASCADE)
+    public = models.BooleanField(verbose_name=_l('Public'), default=True)
+    complaint = models.ForeignKey(Complaint, editable=False, verbose_name=_l('Complaint'), on_delete=models.CASCADE)
 
-    person = models.ForeignKey(Person, editable=False, verbose_name=_('Person'), on_delete=models.PROTECT)
-    comment = models.TextField(verbose_name=_('Remarks'))
+    person = models.ForeignKey(Person, editable=False, verbose_name=_l('Person'), on_delete=models.PROTECT)
+    comment = models.TextField(verbose_name=_l('Remarks'))
 
     objects = ComplaintCommentManager()
 
     class Meta:
         ordering = ['complaint', '-published']
-        verbose_name = _('Comment on a complaint')
-        verbose_name_plural = _('Comments on a complaint')
+        verbose_name = _l('Comment on a complaint')
+        verbose_name_plural = _l('Comments on a complaint')
 
 
 class Competition(models.Model):
@@ -304,8 +304,8 @@ class Competition(models.Model):
     title = models.CharField(max_length=100)
 
     class Meta:
-        verbose_name = _('Game')
-        verbose_name_plural = _('Games')
+        verbose_name = _l('Game')
+        verbose_name_plural = _l('Games')
 
     def __str__(self):
         return '%s' % self.title
@@ -320,8 +320,8 @@ class Vote(models.Model):
     competition = models.ForeignKey(Competition, editable=False, on_delete=models.CASCADE)
 
     class Meta:
-        verbose_name = _('Vote')
-        verbose_name_plural = _('Votes')
+        verbose_name = _l('Vote')
+        verbose_name_plural = _l('Votes')
 
 
 class EducationEvent(Event):

--- a/amelie/files/models.py
+++ b/amelie/files/models.py
@@ -10,7 +10,7 @@ from django.conf import settings
 from django.db import models
 from django.http import HttpResponse, HttpResponseForbidden, Http404
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.files.managers import AttachmentManager
 from amelie.members.models import Photographer
@@ -146,8 +146,8 @@ class Attachment(models.Model):
 
     class Meta:
         ordering = ['created', 'file']
-        verbose_name = _('Appendix')
-        verbose_name_plural = _('Attachments')
+        verbose_name = _l('Appendix')
+        verbose_name_plural = _l('Attachments')
 
     def __str__(self):
         if self.caption:
@@ -196,7 +196,7 @@ class Attachment(models.Model):
             photo_file = self.file
 
         if photo_file is None:
-            return Http404(_("File not found"))
+            return Http404(_l("File not found"))
 
         # Create a response
         if response == 'json':

--- a/amelie/forms.py
+++ b/amelie/forms.py
@@ -1,12 +1,12 @@
 from django import forms
 from django.contrib.auth.forms import AuthenticationForm
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.style.forms import inject_style
 
 
 class AmelieAuthenticationForm(AuthenticationForm):
-    remain_logged_in = forms.BooleanField(required=False, label=_('Stay logged in'))
+    remain_logged_in = forms.BooleanField(required=False, label=_l('Stay logged in'))
 
 
 inject_style(AmelieAuthenticationForm)

--- a/amelie/members/forms.py
+++ b/amelie/members/forms.py
@@ -13,8 +13,8 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db.models import Q, TextChoices
 from django.forms import widgets
 from django.forms.models import BaseInlineFormSet
-from django.utils.translation import gettext_lazy as _
-from django.utils.translation import gettext
+from django.utils.translation import gettext_lazy as _l
+from django.utils.translation import gettext as _
 from localflavor.generic.forms import BICFormField, IBANFormField
 
 from amelie.iamailer.mailtask import MailTask, Recipient
@@ -30,13 +30,13 @@ from amelie.tools.encodings import normalize_to_ascii
 
 
 class PersonalDetailsEditForm(forms.ModelForm):
-    gender = forms.ChoiceField(choices=Person.GenderTypes.choices, widget=widgets.RadioSelect, label=_('Gender'))
-    preferred_language = forms.ChoiceField(choices=LANGUAGE_CHOICES, widget=widgets.RadioSelect, label=_('Language of preference'))
+    gender = forms.ChoiceField(choices=Person.GenderTypes.choices, widget=widgets.RadioSelect, label=_l('Gender'))
+    preferred_language = forms.ChoiceField(choices=LANGUAGE_CHOICES, widget=widgets.RadioSelect, label=_l('Language of preference'))
     international_member = forms.ChoiceField(choices=Person.InternationalChoices.choices, widget=widgets.RadioSelect,
-                                             label=_("International student"))
-    date_of_birth = forms.DateField(widget=DateSelector, label=_('Birth date'))
+                                             label=_l("International student"))
+    date_of_birth = forms.DateField(widget=DateSelector, label=_l('Birth date'))
     preferences = forms.ModelMultipleChoiceField(Preference.objects.filter(adjustable=True), required=False,
-                                                 widget=widgets.CheckboxSelectMultiple, label=_('Preferences'))
+                                                 widget=widgets.CheckboxSelectMultiple, label=_l('Preferences'))
 
     def save(self, *args, **kwargs):
         if self.has_changed():
@@ -98,13 +98,13 @@ class PersonalDetailsEditForm(forms.ModelForm):
 class PersonalStudyEditForm(forms.Form):
     master = forms.ModelChoiceField(Study.objects.filter(primary_study=True, type=Study.StudyTypes.MSC, active=True),
                                     required=False)
-    finished = forms.DateField(widget=DateSelector, initial=None, required=False, label=_('Bachelor degree'))
-    started = forms.DateField(widget=DateSelector, initial=None, label=_('Started mastereducation'), required=False)
+    finished = forms.DateField(widget=DateSelector, initial=None, required=False, label=_l('Bachelor degree'))
+    started = forms.DateField(widget=DateSelector, initial=None, label=_l('Started mastereducation'), required=False)
 
     def clean(self):
         if 'master' in self.cleaned_data and self.cleaned_data['master'] and (
                         'started' not in self.cleaned_data or not self.cleaned_data['started']):
-            raise forms.ValidationError(_('Please fill in a start date when filling in a mastercourse.'))
+            raise forms.ValidationError(_l('Please fill in a start date when filling in a mastercourse.'))
         return self.cleaned_data
 
     def save(self, study_period):
@@ -141,7 +141,7 @@ class PersonDataForm(forms.ModelForm):
                 self.fields['account_name'].disabled = True
             else:
                 account_name_suggestion = re.sub(r'[^\w\s]', '', normalize_to_ascii(f"{instance.last_name_prefix}{instance.last_name}{instance.initials}")).lower()
-                self.fields['account_name'].help_text = " ".join([gettext("Suggestion:"), account_name_suggestion])
+                self.fields['account_name'].help_text = " ".join([_("Suggestion:"), account_name_suggestion])
 
 
 class PersonPreferencesForm(forms.ModelForm):
@@ -198,7 +198,7 @@ class PersonPreferencesForm(forms.ModelForm):
 
 class EmployeeForm(forms.ModelForm):
     departments = forms.ModelMultipleChoiceField(Department.objects.all(), required=False,
-                                                 widget=widgets.CheckboxSelectMultiple, label=_('Related to'))
+                                                 widget=widgets.CheckboxSelectMultiple, label=_l('Related to'))
 
     class Meta:
         model = Employee
@@ -226,7 +226,7 @@ class PersonPaymentForm(forms.Form):
 
 class MembershipForm(forms.ModelForm):
     year = forms.IntegerField(initial=current_association_year, widget=widgets.RadioSelect())
-    type = forms.ModelChoiceField(MembershipType.objects.filter(active=True), label=_('Type'))
+    type = forms.ModelChoiceField(MembershipType.objects.filter(active=True), label=_l('Type'))
 
     class Meta:
         model = Membership
@@ -234,8 +234,8 @@ class MembershipForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(MembershipForm, self).__init__(*args, **kwargs)
-        self.fields['year'].widget.choices = ((current_association_year(), _('Current association year')),
-                                              (current_association_year() + 1, _('Upcoming association year')),)
+        self.fields['year'].widget.choices = ((current_association_year(), _l('Current association year')),
+                                              (current_association_year() + 1, _l('Upcoming association year')),)
 
 
 class MembershipEndForm(forms.ModelForm):
@@ -247,9 +247,9 @@ class MembershipEndForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(MembershipEndForm, self).__init__(*args, **kwargs)
-        self.fields['ended'].widget.choices = ((date.today(), _('Immediately')),
+        self.fields['ended'].widget.choices = ((date.today(), _l('Immediately')),
                                                (date(current_association_year() + 1, 7, 1),
-                                                _('At the end of the association year')),)
+                                                _l('At the end of the association year')),)
 
 
 class MandateForm(forms.ModelForm):
@@ -273,11 +273,11 @@ class MandateForm(forms.ModelForm):
 
         if not cleaned_data['bic']:
             if not cleaned_data['iban'][:2] == 'NL':
-                raise forms.ValidationError(_('BIC has to be entered for foreign bankaccounts.'))
+                raise forms.ValidationError(_l('BIC has to be entered for foreign bankaccounts.'))
             elif cleaned_data['iban'][4:8] in settings.COOKIE_CORNER_BANK_CODES:
                 cleaned_data['bic'] = settings.COOKIE_CORNER_BANK_CODES[cleaned_data['iban'][4:8]]
             else:
-                raise forms.ValidationError(_('BIC could not be generated, please enter yourself.'))
+                raise forms.ValidationError(_l('BIC could not be generated, please enter yourself.'))
         return cleaned_data
 
 
@@ -292,12 +292,12 @@ class MandateEndForm(forms.ModelForm):
 
 
 class PersonSearchForm(forms.Form):
-    person = forms.IntegerField(widget=MemberSelect(attrs={'autofocus': 'autofocus'}), label=_('Person'),
-                                error_messages={'required': _('Choose a name from the suggestions.')})
+    person = forms.IntegerField(widget=MemberSelect(attrs={'autofocus': 'autofocus'}), label=_l('Person'),
+                                error_messages={'required': _l('Choose a name from the suggestions.')})
 
 
 class SearchForm(forms.Form):
-    search = forms.CharField(max_length=40, label=_('Search'),
+    search = forms.CharField(max_length=40, label=_l('Search'),
                              widget=widgets.TextInput(attrs={'accesskey': 'f', 'autofocus': 'autofocus', }))
 
 
@@ -319,8 +319,8 @@ class PersonCreateForm(forms.ModelForm):
         Q(name_nl='Studielang (eerste jaar)') | Q(name_nl='Medewerker jaar')
     ), required=True, empty_label=None, widget=widgets.RadioSelect)
 
-    iban = IBANFormField(label=_('IBAN'), required=False, widget=forms.TextInput(attrs={'autocomplete': 'off'}))
-    bic = BICFormField(label=_('BIC'), required=False)
+    iban = IBANFormField(label=_l('IBAN'), required=False, widget=forms.TextInput(attrs={'autocomplete': 'off'}))
+    bic = BICFormField(label=_l('BIC'), required=False)
     mandate_contribution = forms.BooleanField(required=False)
     mandate_other = forms.BooleanField(required=False)
 
@@ -351,29 +351,29 @@ class PersonCreateForm(forms.ModelForm):
             # Generation is mandatory if study is chosen
             if 'generation' not in cleaned_data or not cleaned_data['generation']:
                 raise forms.ValidationError(
-                    _("A study has been chosen, but no cohort was specified. Enter the missing data to continue.")
+                    _l("A study has been chosen, but no cohort was specified. Enter the missing data to continue.")
                 )
 
         if cleaned_data['mandate_contribution'] or cleaned_data['mandate_other']:
             if not cleaned_data['iban']:
-                raise forms.ValidationError(_('IBAN is required if a mandate is checked!'))
+                raise forms.ValidationError(_l('IBAN is required if a mandate is checked!'))
             if not cleaned_data['bic']:
                 if not cleaned_data['iban'][:2] == 'NL':
-                    raise forms.ValidationError(_('BIC has to be entered for foreign bankaccounts.'))
+                    raise forms.ValidationError(_l('BIC has to be entered for foreign bankaccounts.'))
                 elif cleaned_data['iban'][4:8] in settings.COOKIE_CORNER_BANK_CODES:
                     cleaned_data['bic'] = settings.COOKIE_CORNER_BANK_CODES[cleaned_data['iban'][4:8]]
                 else:
-                    raise forms.ValidationError(_('BIC could not be generated, please enter yourself.'))
+                    raise forms.ValidationError(_l('BIC could not be generated, please enter yourself.'))
 
         return cleaned_data
 
     def clean_student_number(self):
         if self.cleaned_data['student_number'] and Student.objects.filter(
                 number=self.cleaned_data['student_number']).exists():
-            raise forms.ValidationError(_("A student with this student number already exists."))
+            raise forms.ValidationError(_l("A student with this student number already exists."))
         if self.cleaned_data['student_number'] and UnverifiedEnrollment.objects.filter(
             student_number=self.cleaned_data['student_number']).exists():
-            raise forms.ValidationError(_("This student number is already pre-enrolled. A board member can activate your account."))
+            raise forms.ValidationError(_l("This student number is already pre-enrolled. A board member can activate your account."))
         return self.cleaned_data['student_number']
 
     def save(self, *args, **kwargs):
@@ -398,8 +398,8 @@ class RegistrationForm(forms.ModelForm):
             Q(name_nl='Primair jaarlid') | Q(name_nl='Studielang (eerste jaar)')
     ), required=True, empty_label=None, widget=widgets.RadioSelect)
 
-    iban = IBANFormField(label=_('IBAN'), required=False, widget=forms.TextInput(attrs={'autocomplete': 'off'}))
-    bic = BICFormField(label=_('BIC'), required=False)
+    iban = IBANFormField(label=_l('IBAN'), required=False, widget=forms.TextInput(attrs={'autocomplete': 'off'}))
+    bic = BICFormField(label=_l('BIC'), required=False)
     mandate_contribution = forms.BooleanField(required=False)
     mandate_other = forms.BooleanField(required=False)
 
@@ -435,22 +435,22 @@ class RegistrationForm(forms.ModelForm):
 
         if cleaned_data['mandate_contribution'] or cleaned_data['mandate_other']:
             if not cleaned_data['iban']:
-                raise forms.ValidationError(_('IBAN is required if a mandate is checked!'))
+                raise forms.ValidationError(_l('IBAN is required if a mandate is checked!'))
             if not cleaned_data['bic']:
                 if not cleaned_data['iban'][:2] == 'NL':
-                    raise forms.ValidationError(_('BIC has to be entered for foreign bankaccounts.'))
+                    raise forms.ValidationError(_l('BIC has to be entered for foreign bankaccounts.'))
                 elif cleaned_data['iban'][4:8] in settings.COOKIE_CORNER_BANK_CODES:
                     cleaned_data['bic'] = settings.COOKIE_CORNER_BANK_CODES[cleaned_data['iban'][4:8]]
                 else:
-                    raise forms.ValidationError(_('BIC could not be generated, please enter yourself.'))
+                    raise forms.ValidationError(_l('BIC could not be generated, please enter yourself.'))
 
         return cleaned_data
 
     def clean_student_number(self):
         if Student.objects.filter(number=self.cleaned_data['student_number']).exists():
-            raise forms.ValidationError(_("A student with this student number already exists."))
+            raise forms.ValidationError(_l("A student with this student number already exists."))
         if UnverifiedEnrollment.objects.filter(student_number=self.cleaned_data['student_number']).exists():
-            raise forms.ValidationError(_("This student number is already pre-enrolled. A board member can activate your account."))
+            raise forms.ValidationError(_l("This student number is already pre-enrolled. A board member can activate your account."))
         return self.cleaned_data['student_number']
 
     def save(self, *args, **kwargs):
@@ -510,12 +510,12 @@ class RegistrationFormStepParentsContactDetails(forms.ModelForm):
 
         # If we can use the data, but no (basic) data is given, error out.
         if can_use_data and not email_address:
-            raise forms.ValidationError(_("If we can use your parent(s)/guardian(s) data, "
+            raise forms.ValidationError(_l("If we can use your parent(s)/guardian(s) data, "
                                           "then you need to enter at least their e-mail address!"))
 
         # If we cannot use the data, but data is given, error out.
         if not can_use_data and any([address, postal_code, city, country, email_address]):
-            raise forms.ValidationError(_("If we can not use your parent(s)/guardian(s) data, "
+            raise forms.ValidationError(_l("If we can not use your parent(s)/guardian(s) data, "
                                           "then you do not need to enter any data!"))
 
         return cleaned_data
@@ -538,23 +538,23 @@ class RegistrationFormStepGeneralStudyDetails(forms.Form):
         if ('generation' not in cleaned_data.keys() or not cleaned_data['generation']) and \
                 ('study' in cleaned_data.keys() and cleaned_data['study']):
             raise forms.ValidationError(
-                _("A study has been chosen, but no cohort was specified. Enter the missing data to continue.")
+                _l("A study has been chosen, but no cohort was specified. Enter the missing data to continue.")
             )
 
         # Study is mandatory if generation is chosen
         if ('study' not in cleaned_data.keys() or not cleaned_data['study']) and \
                 ('generation' in cleaned_data.keys() and cleaned_data['generation']):
             raise forms.ValidationError(
-                _("A cohort has been chosen, but no study was specified. Enter at least one study to continue.")
+                _l("A cohort has been chosen, but no study was specified. Enter at least one study to continue.")
             )
 
         return cleaned_data
 
     def clean_student_number(self):
         if Student.objects.filter(number=self.cleaned_data['student_number']).exists():
-            raise forms.ValidationError(_("A student with this student number already exists."))
+            raise forms.ValidationError(_l("A student with this student number already exists."))
         if UnverifiedEnrollment.objects.filter(student_number=self.cleaned_data['student_number']).exists():
-            raise forms.ValidationError(_("This student number is already pre-enrolled. A board member can activate your account."))
+            raise forms.ValidationError(_l("This student number is already pre-enrolled. A board member can activate your account."))
         return self.cleaned_data['student_number']
 
 
@@ -570,9 +570,9 @@ class RegistrationFormStepFreshmenStudyDetails(forms.Form):
 
     def clean_student_number(self):
         if Student.objects.filter(number=self.cleaned_data['student_number']).exists():
-            raise forms.ValidationError(_("A student with this student number already exists."))
+            raise forms.ValidationError(_l("A student with this student number already exists."))
         if UnverifiedEnrollment.objects.filter(student_number=self.cleaned_data['student_number']).exists():
-            raise forms.ValidationError(_("This student number is already pre-enrolled. A board member can activate your account."))
+            raise forms.ValidationError(_l("This student number is already pre-enrolled. A board member can activate your account."))
         return self.cleaned_data['student_number']
 
 
@@ -581,7 +581,7 @@ class RegistrationFormStepEmployeeDetails(forms.Form):
 
     def clean_employee_number(self):
         if Employee.objects.filter(number=self.cleaned_data['employee_number']).exists():
-            raise forms.ValidationError(_("An employee with this employee number already exists."))
+            raise forms.ValidationError(_l("An employee with this employee number already exists."))
         return self.cleaned_data['employee_number']
 
 
@@ -606,12 +606,12 @@ class RegistrationFormStepFreshmenMembershipDetails(forms.Form):
 class RegistrationFormStepAuthorizationDetails(forms.Form):
     authorization_contribution = forms.BooleanField(required=False)
     authorization_other = forms.BooleanField(required=False)
-    iban = IBANFormField(label=_('IBAN'), required=False, widget=forms.TextInput(attrs={'autocomplete': 'off'}))
-    bic = BICFormField(label=_('BIC'), required=False)
+    iban = IBANFormField(label=_l('IBAN'), required=False, widget=forms.TextInput(attrs={'autocomplete': 'off'}))
+    bic = BICFormField(label=_l('BIC'), required=False)
 
     def clean_iban(self):
         if str(self.cleaned_data['iban']).strip() == "NL18ABNA0484869868":
-            raise forms.ValidationError(_("Please enter your own bank account number!"))
+            raise forms.ValidationError(_l("Please enter your own bank account number!"))
         return self.cleaned_data['iban']
 
     def clean_bic(self):
@@ -636,7 +636,7 @@ class RegistrationFormStepAuthorizationDetails(forms.Form):
                 raise IOError(u"Reading file at {} failed (run 'manage.py update_bic_csv' to create it if it does not exist) {}"
                               .format(os.path.join(settings.MEDIA_ROOT, 'bic_list.csv'), e))
 
-            raise forms.ValidationError(_("BIC is not from a SEPA country"))
+            raise forms.ValidationError(_l("BIC is not from a SEPA country"))
 
     def clean(self):
         cleaned_data = super(RegistrationFormStepAuthorizationDetails, self).clean()
@@ -647,14 +647,14 @@ class RegistrationFormStepAuthorizationDetails(forms.Form):
 
         if cleaned_data['authorization_contribution'] or cleaned_data['authorization_other']:
             if not cleaned_data['iban']:
-                raise forms.ValidationError(_('IBAN is required if a mandate is checked!'))
+                raise forms.ValidationError(_l('IBAN is required if a mandate is checked!'))
             if not cleaned_data['bic']:
                 if not cleaned_data['iban'][:2] == 'NL':
-                    raise forms.ValidationError(_('BIC has to be entered for foreign bankaccounts.'))
+                    raise forms.ValidationError(_l('BIC has to be entered for foreign bankaccounts.'))
                 elif cleaned_data['iban'][4:8] in settings.COOKIE_CORNER_BANK_CODES:
                     cleaned_data['bic'] = settings.COOKIE_CORNER_BANK_CODES[cleaned_data['iban'][4:8]]
                 else:
-                    raise forms.ValidationError(_('BIC could not be generated, please enter yourself.'))
+                    raise forms.ValidationError(_l('BIC could not be generated, please enter yourself.'))
 
         return cleaned_data
 
@@ -685,10 +685,10 @@ class RegistrationFormStepFinalCheck(forms.Form):
 
 class PreRegistrationPrintAllForm(forms.Form):
     class SortOptions(TextChoices):
-        LAST_NAME = 'last_name', _('By last name')
-        FIRST_NAME = 'first_name', _('By first name')
-        STUDENT_NUMBER = 'student_number', _('By student number')
-        ID = 'id', _('By order of pre-enrollment')
+        LAST_NAME = 'last_name', _l('By last name')
+        FIRST_NAME = 'first_name', _l('By first name')
+        STUDENT_NUMBER = 'student_number', _l('By student number')
+        ID = 'id', _l('By order of pre-enrollment')
 
     sort_by = forms.ChoiceField(choices=SortOptions.choices, required=True, initial=SortOptions.LAST_NAME)
     group_by_dogroup = forms.BooleanField(required=False, label="Group forms by do-group?", initial=True)
@@ -698,7 +698,7 @@ class PreRegistrationPrintAllForm(forms.Form):
 
 class FunctionForm(forms.ModelForm):
     committee = forms.ModelChoiceField(queryset=Committee.objects.non_parent_committees())
-    function = forms.CharField(max_length=75, label=_('Position'))
+    function = forms.CharField(max_length=75, label=_l('Position'))
 
     class Meta:
         model = Function
@@ -732,9 +732,9 @@ class CommitteeMemberForm(forms.ModelForm):
 class CommitteeForm(forms.ModelForm):
     abbreviation = forms.RegexField(regex="[A-Za-z0-9]+", max_length=20)
     category = forms.ModelChoiceField(CommitteeCategory.objects.all(), widget=forms.Select, required=False,
-                                      label=_('Category'))
+                                      label=_l('Category'))
     parent_committees = forms.ModelMultipleChoiceField(Committee.objects.active(), widget=forms.SelectMultiple,
-                                                       label=_('Parent committee'), required=False)
+                                                       label=_l('Parent committee'), required=False)
 
     class Meta:
         model = Committee
@@ -753,11 +753,11 @@ class SaveNewFirstModelFormSet(BaseInlineFormSet):
 
 
 class StudentNumberForm(forms.Form):
-    student_number = forms.IntegerField(label=_('Student number'))
+    student_number = forms.IntegerField(label=_l('Student number'))
 
     def clean_student_number(self):
         if not Student.objects.filter(number=self.cleaned_data["student_number"]).exists():
-            raise forms.ValidationError(_("There is no student with this student number."))
+            raise forms.ValidationError(_l("There is no student with this student number."))
         return self.cleaned_data["student_number"]
 
 

--- a/amelie/members/models.py
+++ b/amelie/members/models.py
@@ -16,7 +16,7 @@ from django.db.models.signals import post_save, m2m_changed
 from django.template.defaultfilters import slugify
 from django.urls import reverse
 from django.utils.translation import get_language
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.claudia.mappable import Mappable
 from amelie.claudia.tools import is_verifiable, verify_instance
@@ -25,7 +25,7 @@ from amelie.tools.encodings import normalize_to_ascii
 from amelie.tools.logic import current_association_year
 from amelie.tools.validators import CheckDigitValidator
 
-LANGUAGE_CHOICES = [(l[0], _(l[1])) for l in settings.LANGUAGES]
+LANGUAGE_CHOICES = [(l[0], _l(l[1])) for l in settings.LANGUAGES]
 
 
 class Faculty(models.Model):
@@ -33,13 +33,13 @@ class Faculty(models.Model):
     A faculty, e.g. EEMCS. Studies and research groups are linked using their respective models.
     Because of imports in the education module they are found in the members module.
     """
-    name = models.CharField(max_length=100, verbose_name=_('Name'))
-    abbreviation = models.CharField(max_length=10, verbose_name=_('Abbreviation'))
+    name = models.CharField(max_length=100, verbose_name=_l('Name'))
+    abbreviation = models.CharField(max_length=10, verbose_name=_l('Abbreviation'))
 
     class Meta(object):
         ordering = ['name']
-        verbose_name = _('faculty')
-        verbose_name_plural = _('faculties')
+        verbose_name = _l('faculty')
+        verbose_name_plural = _l('faculties')
 
     def __str__(self):
         return '%s (%s)' % (self.name, self.abbreviation)
@@ -51,18 +51,18 @@ class Department(models.Model):
     Because of imports in the education module they are found in the members module.
     """
     class DepartmentTypes(models.TextChoices):
-        RESEARCH_GROUP = 'researchgroup', _('Chair')
-        SERVICE = 'service', _('Service')
+        RESEARCH_GROUP = 'researchgroup', _l('Chair')
+        SERVICE = 'service', _l('Service')
 
-    name = models.CharField(max_length=100, verbose_name=_('Name'))
-    abbreviation = models.CharField(max_length=10, verbose_name=_('Abbreviation'))
-    faculty = models.ForeignKey(Faculty, null=True, blank=True, verbose_name=_('Faculty'), on_delete=models.SET_NULL)
-    type = models.CharField(max_length=15, choices=DepartmentTypes.choices, verbose_name=_('Type'))
+    name = models.CharField(max_length=100, verbose_name=_l('Name'))
+    abbreviation = models.CharField(max_length=10, verbose_name=_l('Abbreviation'))
+    faculty = models.ForeignKey(Faculty, null=True, blank=True, verbose_name=_l('Faculty'), on_delete=models.SET_NULL)
+    type = models.CharField(max_length=15, choices=DepartmentTypes.choices, verbose_name=_l('Type'))
 
     class Meta(object):
         ordering = ['name']
-        verbose_name = _('department')
-        verbose_name_plural = _('departments')
+        verbose_name = _l('department')
+        verbose_name_plural = _l('departments')
 
     def __str__(self):
         return '%s (%s)' % (self.name, self.abbreviation)
@@ -74,25 +74,25 @@ class Study(models.Model):
     Because of imports in the education module they are found in the members module.
     """
     class StudyTypes(models.TextChoices):
-        BSC = 'BSc', _('Bachelor of Science')
-        MSC = 'MSc', _('Master of Science')
-        IR = 'Ir', _('Engineer')
+        BSC = 'BSc', _l('Bachelor of Science')
+        MSC = 'MSc', _l('Master of Science')
+        IR = 'Ir', _l('Engineer')
 
-    name_nl = models.CharField(max_length=100, verbose_name=_('Name'))
-    name_en = models.CharField(max_length=100, verbose_name=_('Name (en)'), blank=True)
-    abbreviation = models.CharField(max_length=10, verbose_name=_('Abbreviation'))
-    faculties = models.ManyToManyField(Faculty, verbose_name=_('Faculties'))
-    type = models.CharField(max_length=3, choices=StudyTypes.choices, verbose_name=_('Type'))
-    length = models.IntegerField(verbose_name=_('Course length'))
+    name_nl = models.CharField(max_length=100, verbose_name=_l('Name'))
+    name_en = models.CharField(max_length=100, verbose_name=_l('Name (en)'), blank=True)
+    abbreviation = models.CharField(max_length=10, verbose_name=_l('Abbreviation'))
+    faculties = models.ManyToManyField(Faculty, verbose_name=_l('Faculties'))
+    type = models.CharField(max_length=3, choices=StudyTypes.choices, verbose_name=_l('Type'))
+    length = models.IntegerField(verbose_name=_l('Course length'))
     primary_study = models.BooleanField(
         default=False,
-        verbose_name=_("Primary study"),
-        help_text=_("Indicates that this study is one of our primary studies")
+        verbose_name=_l("Primary study"),
+        help_text=_l("Indicates that this study is one of our primary studies")
     )
     active = models.BooleanField(
         default=True,
-        verbose_name=_("Active"),
-        help_text=_("Make a study inactive when the study is not given any more on the University of Twente"),
+        verbose_name=_l("Active"),
+        help_text=_l("Make a study inactive when the study is not given any more on the University of Twente"),
     )
 
     @property
@@ -106,8 +106,8 @@ class Study(models.Model):
 
     class Meta(object):
         ordering = ['abbreviation']
-        verbose_name = _('study')
-        verbose_name_plural = _('studies')
+        verbose_name = _l('study')
+        verbose_name_plural = _l('studies')
 
     def __str__(self):
         return '%s (%s)' % (self.name, self.abbreviation)
@@ -118,14 +118,14 @@ class Dogroup(models.Model):
     A do-group such as these are created over the years:
     e.g. Tegel, TuinfeesT
     """
-    name = models.CharField(verbose_name=_('Name'), max_length=50)
-    color = ColorField(verbose_name=_('Color'), help_text=_("What is the color of this dogroup?"),
+    name = models.CharField(verbose_name=_l('Name'), max_length=50)
+    color = ColorField(verbose_name=_l('Color'), help_text=_l("What is the color of this dogroup?"),
                        default="#000000")
 
     class Meta(object):
         ordering = ['name']
-        verbose_name = _('do-group')
-        verbose_name_plural = _('do-groups')
+        verbose_name = _l('do-group')
+        verbose_name_plural = _l('do-groups')
 
     def __str__(self):
         return self.name
@@ -137,18 +137,18 @@ class DogroupGeneration(models.Model, Mappable):
     privacy regulations. Refer to https://privacy.ia.utwente.nl/ and check whether processing the property is allowed
     for your purpose.
     """
-    generation = models.PositiveIntegerField(verbose_name=_('Generation'))
-    dogroup = models.ForeignKey(Dogroup, verbose_name=_('Dogroup'), on_delete=models.PROTECT)
-    parents = models.ManyToManyField('Person', verbose_name=_('Introduction parents'), blank=True)
-    study = models.ForeignKey(Study, verbose_name=_('Course'), on_delete=models.PROTECT)
-    mail_alias = models.EmailField(verbose_name=_('Mailalias'))
-    generation_color = ColorField(verbose_name=_('Generation color'), blank=True, null=True,
-                                  help_text=_("Similar to the dogroup color, however this value can be set in order to override the color for just this generation"))
+    generation = models.PositiveIntegerField(verbose_name=_l('Generation'))
+    dogroup = models.ForeignKey(Dogroup, verbose_name=_l('Dogroup'), on_delete=models.PROTECT)
+    parents = models.ManyToManyField('Person', verbose_name=_l('Introduction parents'), blank=True)
+    study = models.ForeignKey(Study, verbose_name=_l('Course'), on_delete=models.PROTECT)
+    mail_alias = models.EmailField(verbose_name=_l('Mailalias'))
+    generation_color = ColorField(verbose_name=_l('Generation color'), blank=True, null=True,
+                                  help_text=_l("Similar to the dogroup color, however this value can be set in order to override the color for just this generation"))
 
     class Meta(object):
         ordering = ['generation', 'dogroup']
-        verbose_name = _('do-group generation')
-        verbose_name_plural = _('do-group generations')
+        verbose_name = _l('do-group generation')
+        verbose_name_plural = _l('do-group generations')
 
     @property
     def color(self):
@@ -160,7 +160,7 @@ class DogroupGeneration(models.Model, Mappable):
     def clean(self):
         super(DogroupGeneration, self).clean()
         if not any(self.mail_alias.endswith(domain) for domain in settings.IA_MAIL_DOMAIN):
-            raise ValidationError({'email': _(
+            raise ValidationError({'email': _l(
                 'The mail alias for a dogroup generation may only point to an Inter-Actief server.'
             )})
 
@@ -171,7 +171,7 @@ class DogroupGeneration(models.Model, Mappable):
             # Already in use, if it's us, then it's fine
             if len(Mapping.objects.filter(email=self.mail_alias)) > 1 or \
                 Mapping.objects.get(email=self.mail_alias).get_mapped_object() != self:
-                raise ValidationError({'email': _(
+                raise ValidationError({'email': _l(
                     'This email address is already in use by another mapping!'
                 )})
 
@@ -215,13 +215,13 @@ class Association(models.Model):
     """
     Study assocation for secundary members (e.g. Scintilla).
     """
-    name = models.CharField(max_length=100, verbose_name=_('Name'))
-    studies = models.ManyToManyField(Study, blank=True, verbose_name=_('Courses'))
+    name = models.CharField(max_length=100, verbose_name=_l('Name'))
+    studies = models.ManyToManyField(Study, blank=True, verbose_name=_l('Courses'))
 
     class Meta(object):
         ordering = ['name']
-        verbose_name = _('association')
-        verbose_name_plural = _('associations')
+        verbose_name = _l('association')
+        verbose_name_plural = _l('associations')
 
     def __str__(self):
         return '%s' % self.name
@@ -231,11 +231,11 @@ class PreferenceCategory(models.Model):
     """
     A category for preferences.
     """
-    name = models.CharField(max_length=30, verbose_name=_('Category of preference'))
+    name = models.CharField(max_length=30, verbose_name=_l('Category of preference'))
 
     class Meta(object):
-        verbose_name = _('category of preference')
-        verbose_name_plural = _('categories of preference')
+        verbose_name = _l('category of preference')
+        verbose_name_plural = _l('categories of preference')
 
     def __str__(self):
         return '%s' % self.name
@@ -245,14 +245,14 @@ class Preference(models.Model):
     """
     Preference of a person, e.g. if they want the weekly mail.
     """
-    name = models.CharField(max_length=30, verbose_name=_('Name'))
-    preference_nl = models.CharField(max_length=200, verbose_name=_('Preference'))
-    preference_en = models.CharField(max_length=200, verbose_name=_('Preference(s)'))
+    name = models.CharField(max_length=30, verbose_name=_l('Name'))
+    preference_nl = models.CharField(max_length=200, verbose_name=_l('Preference'))
+    preference_en = models.CharField(max_length=200, verbose_name=_l('Preference(s)'))
     category = models.ForeignKey(PreferenceCategory, on_delete=models.PROTECT)
-    default = models.BooleanField(default=False, verbose_name=_('Standard'))
-    adjustable = models.BooleanField(default=False, verbose_name=_('Adjustable by the user in profile'))
-    first_time = models.BooleanField(default=False, verbose_name=_('Adjustable by the user on login'))
-    print = models.BooleanField(default=False, verbose_name=_('Print'))
+    default = models.BooleanField(default=False, verbose_name=_l('Standard'))
+    adjustable = models.BooleanField(default=False, verbose_name=_l('Adjustable by the user in profile'))
+    first_time = models.BooleanField(default=False, verbose_name=_l('Adjustable by the user on login'))
+    print = models.BooleanField(default=False, verbose_name=_l('Print'))
 
     @property
     def preference(self):
@@ -265,8 +265,8 @@ class Preference(models.Model):
 
     class Meta(object):
         ordering = ['name', 'preference_nl']
-        verbose_name = _('preference')
-        verbose_name_plural = _('preference')
+        verbose_name = _l('preference')
+        verbose_name_plural = _l('preference')
 
     def __str__(self):
         return '%s' % self.preference
@@ -284,84 +284,84 @@ class Person(models.Model, Mappable):
     allowed for your purpose.
     """
     class GenderTypes(models.TextChoices):
-        UNKNOWN = 'Unknown', _('Unknown')
-        MAN = 'Man', _('Man')
-        WOMAN = 'Woman', _('Woman')
-        OTHER = 'Other', _('Other')
+        UNKNOWN = 'Unknown', _l('Unknown')
+        MAN = 'Man', _l('Man')
+        WOMAN = 'Woman', _l('Woman')
+        OTHER = 'Other', _l('Other')
 
     class InternationalChoices(models.TextChoices):
-        YES = 'Yes', _('Yes, I am an international student.')
-        NO = 'No', _('No, I am not an international student.')
-        UNKNOWN = 'Unknown', _('I would rather not say if I\'m an international student or not.')
+        YES = 'Yes', _l('Yes, I am an international student.')
+        NO = 'No', _l('No, I am not an international student.')
+        UNKNOWN = 'Unknown', _l('I would rather not say if I\'m an international student or not.')
 
     class ShellChoices(models.TextChoices):
-        DEFAULT = 'default', _('No preference')
-        BASH = 'bash', _('Bash')
-        ZSH = 'zsh', _('Z shell')
+        DEFAULT = 'default', _l('No preference')
+        BASH = 'bash', _l('Bash')
+        ZSH = 'zsh', _l('Z shell')
 
-    first_name = models.CharField(max_length=50, verbose_name=_('First name'))
-    last_name_prefix = models.CharField(max_length=25, blank=True, verbose_name=_('Last name pre-fix'))
-    last_name = models.CharField(max_length=50, verbose_name=_('Last name'))
-    initials = models.CharField(max_length=20, blank=True, verbose_name=_('Initials'))
+    first_name = models.CharField(max_length=50, verbose_name=_l('First name'))
+    last_name_prefix = models.CharField(max_length=25, blank=True, verbose_name=_l('Last name pre-fix'))
+    last_name = models.CharField(max_length=50, verbose_name=_l('Last name'))
+    initials = models.CharField(max_length=20, blank=True, verbose_name=_l('Initials'))
     slug = models.SlugField(max_length=150, editable=False)
-    picture = models.ImageField(upload_to=person_picture_upload_path, blank=True, null=True, verbose_name=_('Photo'))
-    notes = models.TextField(blank=True, verbose_name=_('Notes'))
+    picture = models.ImageField(upload_to=person_picture_upload_path, blank=True, null=True, verbose_name=_l('Photo'))
+    notes = models.TextField(blank=True, verbose_name=_l('Notes'))
 
-    gender = models.CharField(max_length=9, choices=GenderTypes.choices, verbose_name=_('Gender'))
+    gender = models.CharField(max_length=9, choices=GenderTypes.choices, verbose_name=_l('Gender'))
     preferred_language = models.CharField(max_length=100, choices=LANGUAGE_CHOICES, default='nl',
-                                          verbose_name=_('Language of preference'))
+                                          verbose_name=_l('Language of preference'))
     international_member = models.CharField(max_length=16, choices=InternationalChoices.choices,
-                                            verbose_name=_("International student"))
+                                            verbose_name=_l("International student"))
 
-    date_of_birth = models.DateField(null=True, blank=True, verbose_name=_('Birth date'))
+    date_of_birth = models.DateField(null=True, blank=True, verbose_name=_l('Birth date'))
 
-    email_address = models.EmailField(verbose_name=_('E-mail address'), null=True)
-    address = models.CharField(max_length=50, verbose_name=_('Address'))
-    postal_code = models.CharField(max_length=8, verbose_name=_('Postal code'))
-    city = models.CharField(max_length=30, verbose_name=_('City'))
-    country = models.CharField(max_length=25, default='Nederland', verbose_name=_('Country'))
-    telephone = models.CharField(max_length=20, blank=True, verbose_name=_('Phonenumber'))
+    email_address = models.EmailField(verbose_name=_l('E-mail address'), null=True)
+    address = models.CharField(max_length=50, verbose_name=_l('Address'))
+    postal_code = models.CharField(max_length=8, verbose_name=_l('Postal code'))
+    city = models.CharField(max_length=30, verbose_name=_l('City'))
+    country = models.CharField(max_length=25, default='Nederland', verbose_name=_l('Country'))
+    telephone = models.CharField(max_length=20, blank=True, verbose_name=_l('Phonenumber'))
 
-    email_address_parents = models.EmailField(verbose_name=_('E-mail address of parent(s)/guardian(s)'), blank=True)
-    address_parents = models.CharField(max_length=50, blank=True, verbose_name=_('Address of parent(s)/guardian(s)'))
+    email_address_parents = models.EmailField(verbose_name=_l('E-mail address of parent(s)/guardian(s)'), blank=True)
+    address_parents = models.CharField(max_length=50, blank=True, verbose_name=_l('Address of parent(s)/guardian(s)'))
     postal_code_parents = models.CharField(max_length=8, blank=True,
-                                           verbose_name=_('Postal code of parent(s)/guardian(s)'))
+                                           verbose_name=_l('Postal code of parent(s)/guardian(s)'))
     city_parents = models.CharField(max_length=30, blank=True,
-                                    verbose_name=_('Residence of parent(s)/guardian(s)'))
+                                    verbose_name=_l('Residence of parent(s)/guardian(s)'))
     country_parents = models.CharField(max_length=25, blank=True, default='Nederland',
-                                       verbose_name=_('Country of parent(s)/guardian(s)'))
-    can_use_parents_address = models.BooleanField(default=False, verbose_name=_("My parents' address details may be "
+                                       verbose_name=_l('Country of parent(s)/guardian(s)'))
+    can_use_parents_address = models.BooleanField(default=False, verbose_name=_l("My parents' address details may be "
                                                                                 "used for the parents day."))
 
-    account_name = models.CharField(max_length=50, blank=True, verbose_name=_('Account name'), validators=[
-        RegexValidator(r'^[a-z]*$', _('You can only enter ^[a-z]*$.'), _('Invalid account name')),
+    account_name = models.CharField(max_length=50, blank=True, verbose_name=_l('Account name'), validators=[
+        RegexValidator(r'^[a-z]*$', _l('You can only enter ^[a-z]*$.'), _l('Invalid account name')),
         MinLengthValidator(2),
         MaxLengthValidator(20),
     ])
     ut_external_username = models.CharField(
-        max_length=8, blank=True, null=True, verbose_name=_('UT external account name'), validators=[
-            RegexValidator(r'^x[0-9]{7}$', _('You can only enter ^x[0-9]{7}$.'), _('Invalid account name'))
+        max_length=8, blank=True, null=True, verbose_name=_l('UT external account name'), validators=[
+            RegexValidator(r'^x[0-9]{7}$', _l('You can only enter ^x[0-9]{7}$.'), _l('Invalid account name'))
         ]
     )
-    shell = models.CharField(max_length=10, choices=ShellChoices.choices, default=ShellChoices.DEFAULT, verbose_name=_('Unix shell'))
-    webmaster = models.BooleanField(default=False, verbose_name=_('Is web master'))
-    nda = models.BooleanField(default=False, verbose_name=_('Has signed NDA'))
+    shell = models.CharField(max_length=10, choices=ShellChoices.choices, default=ShellChoices.DEFAULT, verbose_name=_l('Unix shell'))
+    webmaster = models.BooleanField(default=False, verbose_name=_l('Is web master'))
+    nda = models.BooleanField(default=False, verbose_name=_l('Has signed NDA'))
 
-    preferences = models.ManyToManyField(Preference, blank=True, verbose_name=_('Preferences'))
-    user = models.OneToOneField(User, null=True, blank=True, related_name='person', verbose_name=_('User'),
+    preferences = models.ManyToManyField(Preference, blank=True, verbose_name=_l('Preferences'))
+    user = models.OneToOneField(User, null=True, blank=True, related_name='person', verbose_name=_l('User'),
                                 on_delete=models.SET_NULL)
 
-    password_reset_code = models.CharField(max_length=50, verbose_name=_("Password reset code"),
+    password_reset_code = models.CharField(max_length=50, verbose_name=_l("Password reset code"),
                                            null=True, blank=True, unique=True, editable=False)
-    password_reset_expiry = models.DateTimeField(verbose_name=_('Password reset code expiry'),
+    password_reset_expiry = models.DateTimeField(verbose_name=_l('Password reset code expiry'),
                                                  null=True, blank=True, editable=False)
 
     objects = PersonManager()
 
     class Meta(object):
         ordering = ['last_name']
-        verbose_name = _('person')
-        verbose_name_plural = _('people')
+        verbose_name = _l('person')
+        verbose_name_plural = _l('people')
 
     def __str__(self):
         return self.incomplete_name()
@@ -675,7 +675,7 @@ class Person(models.Model, Mappable):
             if self.email_address and self.email_address.endswith(domain):
                 if any(alias + domain == self.email_address for alias in self.personal_aliases()) \
                         or self.get_adname() + domain == self.email_address:
-                    raise ValidationError({'email_address': _(
+                    raise ValidationError({'email_address': _l(
                         'Your email address is not to point to an Inter-Actief server. If you have a Google Apps '
                         'account please use firstname.lastname@gapps.inter-actief.nl as an alternative.'
                     )})
@@ -685,13 +685,13 @@ class MembershipType(models.Model):
     """
     A membership type, e.g. Primary member, Studylong member, USW.
     """
-    name_nl = models.CharField(max_length=30, unique=True, verbose_name=_('Name'))
-    name_en = models.CharField(max_length=30, verbose_name=_('Name (en)'), blank=True)
-    description = models.TextField(null=True, blank=True, verbose_name=_('Description'))
-    price = models.DecimalField(max_digits=5, decimal_places=2, verbose_name=_('Price'))
-    needs_verification = models.BooleanField(default=False, verbose_name=_('Needs verification'))
+    name_nl = models.CharField(max_length=30, unique=True, verbose_name=_l('Name'))
+    name_en = models.CharField(max_length=30, verbose_name=_l('Name (en)'), blank=True)
+    description = models.TextField(null=True, blank=True, verbose_name=_l('Description'))
+    price = models.DecimalField(max_digits=5, decimal_places=2, verbose_name=_l('Price'))
+    needs_verification = models.BooleanField(default=False, verbose_name=_l('Needs verification'))
 
-    active = models.BooleanField(default=True, verbose_name=_('Active'))
+    active = models.BooleanField(default=True, verbose_name=_l('Active'))
     """If a membership type is active new memberships of this type can be created."""
 
     @property
@@ -705,8 +705,8 @@ class MembershipType(models.Model):
 
     class Meta(object):
         ordering = ['description']
-        verbose_name = _('membership type')
-        verbose_name_plural = _('membership types')
+        verbose_name = _l('membership type')
+        verbose_name_plural = _l('membership types')
 
     def __str__(self):
         return '{} (€{})'.format(self.name, self.price)
@@ -715,13 +715,13 @@ class PaymentType(models.Model):
     """
     e.g. Cash or Debit transaction
     """
-    name = models.CharField(max_length=20, unique=True, verbose_name=_('Name'))
-    description = models.TextField(verbose_name=_('Description'))
+    name = models.CharField(max_length=20, unique=True, verbose_name=_l('Name'))
+    description = models.TextField(verbose_name=_l('Description'))
 
     class Meta(object):
         ordering = ['description']
-        verbose_name = _('way of payment')
-        verbose_name_plural = _('ways of payment')
+        verbose_name = _l('way of payment')
+        verbose_name_plural = _l('ways of payment')
 
     def __str__(self):
         return '%s' % self.description
@@ -733,13 +733,13 @@ class Student(models.Model):
     Please note that processing properties of this model may be subject to privacy regulations. Refer to
     https://privacy.ia.utwente.nl/ and check whether processing the property is allowed for your purpose.
     """
-    person = models.OneToOneField(Person, verbose_name=_('Person'), on_delete=models.CASCADE)
-    number = models.PositiveIntegerField(verbose_name=_('Student number'), null=True, blank=True, unique=True,
+    person = models.OneToOneField(Person, verbose_name=_l('Person'), on_delete=models.CASCADE)
+    number = models.PositiveIntegerField(verbose_name=_l('Student number'), null=True, blank=True, unique=True,
                                          validators=[CheckDigitValidator(7), MaxValueValidator(9999999)])
 
     class Meta(object):
-        verbose_name = _('student')
-        verbose_name_plural = _('students')
+        verbose_name = _l('student')
+        verbose_name_plural = _l('students')
 
     def __str__(self):
         if self.number is not None:
@@ -762,17 +762,17 @@ class StudyPeriod(models.Model):
     processing properties of this model may be subject to privacy regulations. Refer to https://privacy.ia.utwente.nl/
     and check whether processing the property is allowed for your purpose.
     """
-    student = models.ForeignKey(Student, verbose_name=_('Student'), on_delete=models.CASCADE)
-    study = models.ForeignKey(Study, verbose_name=_('Course'), on_delete=models.PROTECT)
-    begin = models.DateField(verbose_name=_('Begin'))
-    end = models.DateField(null=True, blank=True, verbose_name=_('End'))
-    graduated = models.BooleanField(default=False, verbose_name=_('Has graduated'))
-    dogroup = models.ForeignKey(DogroupGeneration, null=True, blank=True, verbose_name=_('Dogroup'),
+    student = models.ForeignKey(Student, verbose_name=_l('Student'), on_delete=models.CASCADE)
+    study = models.ForeignKey(Study, verbose_name=_l('Course'), on_delete=models.PROTECT)
+    begin = models.DateField(verbose_name=_l('Begin'))
+    end = models.DateField(null=True, blank=True, verbose_name=_l('End'))
+    graduated = models.BooleanField(default=False, verbose_name=_l('Has graduated'))
+    dogroup = models.ForeignKey(DogroupGeneration, null=True, blank=True, verbose_name=_l('Dogroup'),
                                 on_delete=models.SET_NULL)
 
     class Meta(object):
-        verbose_name = _('study period')
-        verbose_name_plural = _('study periods')
+        verbose_name = _l('study period')
+        verbose_name_plural = _l('study periods')
 
     def __str__(self):
         return '%s, %s (%s-%s)' % (self.student, self.study, self.begin, self.end)
@@ -784,15 +784,15 @@ class Employee(models.Model):
     subject to privacy regulations. Refer to https://privacy.ia.utwente.nl/ and check whether processing the property is
     allowed for your purpose.
     """
-    person = models.OneToOneField(Person, verbose_name=_('Person'), on_delete=models.CASCADE)
-    number = models.PositiveIntegerField(blank=True, null=True, unique=True, verbose_name=_('Employee number'),
+    person = models.OneToOneField(Person, verbose_name=_l('Person'), on_delete=models.CASCADE)
+    number = models.PositiveIntegerField(blank=True, null=True, unique=True, verbose_name=_l('Employee number'),
                                          validators=[MinValueValidator(7640000), MaxValueValidator(9999999)])
-    end = models.DateField(null=True, blank=True, verbose_name=_('End'))
+    end = models.DateField(null=True, blank=True, verbose_name=_l('End'))
 
     class Meta(object):
         ordering = ['number']
-        verbose_name = _('employee')
-        verbose_name_plural = _('employees')
+        verbose_name = _l('employee')
+        verbose_name_plural = _l('employees')
 
     def __str__(self):
         if self.number is not None:
@@ -811,9 +811,9 @@ class Photographer(models.Model):
     itself. In order to prevent unnecessary data collection this type of account only stores the first- and lastname of
     a person.
     """
-    first_name = models.CharField(max_length=50, blank=True, verbose_name=_('First name'), null=True)
-    last_name_prefix = models.CharField(max_length=25, blank=True, verbose_name=_('Last name pre-fix'), null=True)
-    last_name = models.CharField(max_length=50, blank=True, verbose_name=_('Last name'), null=True)
+    first_name = models.CharField(max_length=50, blank=True, verbose_name=_l('First name'), null=True)
+    last_name_prefix = models.CharField(max_length=25, blank=True, verbose_name=_l('Last name pre-fix'), null=True)
+    last_name = models.CharField(max_length=50, blank=True, verbose_name=_l('Last name'), null=True)
     person = models.OneToOneField(Person, on_delete=models.CASCADE, null=True, blank=True)
 
     def clean(self):
@@ -824,7 +824,7 @@ class Photographer(models.Model):
         if self.person is not None:
             return
         if (self.first_name is not None and self.last_name is None) or (self.first_name is None and self.last_name is not None):
-            raise ValidationError(_('External photographers should at least have a first- and lastname.'))
+            raise ValidationError(_l('External photographers should at least have a first- and lastname.'))
 
     def __str__(self):
         if self.person is not None:
@@ -845,16 +845,16 @@ class Membership(models.Model):
     Please note that processing properties of this model may be subject to privacy regulations. Refer to
     https://privacy.ia.utwente.nl/ and check whether processing the property is allowed for your purpose.
     """
-    member = models.ForeignKey(Person, verbose_name=_('Member'), on_delete=models.PROTECT)
-    type = models.ForeignKey(MembershipType, verbose_name=_('Type'), on_delete=models.PROTECT)
-    year = models.PositiveIntegerField(verbose_name=_('Year'))
-    ended = models.DateField(null=True, blank=True, verbose_name=_('Ended preliminary'))
-    verified_on = models.DateField(null=True, blank=True, verbose_name=_('Verified on'))
+    member = models.ForeignKey(Person, verbose_name=_l('Member'), on_delete=models.PROTECT)
+    type = models.ForeignKey(MembershipType, verbose_name=_l('Type'), on_delete=models.PROTECT)
+    year = models.PositiveIntegerField(verbose_name=_l('Year'))
+    ended = models.DateField(null=True, blank=True, verbose_name=_l('Ended preliminary'))
+    verified_on = models.DateField(null=True, blank=True, verbose_name=_l('Verified on'))
 
     class Meta(object):
         ordering = ['member', 'year']
-        verbose_name = _('membership')
-        verbose_name_plural = _('memberships')
+        verbose_name = _l('membership')
+        verbose_name_plural = _l('memberships')
 
     def __str__(self):
         return '%s (%s, %s)' % (self.member, self.year, self.type)
@@ -880,16 +880,16 @@ class Payment(models.Model):
     Please note that processing properties of this model may be subject to privacy regulations. Refer to
     https://privacy.ia.utwente.nl/ and check whether processing the property is allowed for your purpose.
     """
-    date = models.DateField(null=True, verbose_name=_('Date'))
-    payment_type = models.ForeignKey(PaymentType, verbose_name=_('Payment'), on_delete=models.PROTECT)
-    amount = models.DecimalField(max_digits=5, decimal_places=2, verbose_name=_('Price'))
+    date = models.DateField(null=True, verbose_name=_l('Date'))
+    payment_type = models.ForeignKey(PaymentType, verbose_name=_l('Payment'), on_delete=models.PROTECT)
+    amount = models.DecimalField(max_digits=5, decimal_places=2, verbose_name=_l('Price'))
 
-    membership = models.OneToOneField(Membership, verbose_name=_('Membership'), on_delete=models.PROTECT)
+    membership = models.OneToOneField(Membership, verbose_name=_l('Membership'), on_delete=models.PROTECT)
 
     class Meta(object):
         ordering = ['date']
-        verbose_name = _('payment')
-        verbose_name_plural = _('payments')
+        verbose_name = _l('payment')
+        verbose_name_plural = _l('payments')
 
     def __str__(self):
         return '%s (%.2f)' % (self.membership, self.amount)
@@ -899,13 +899,13 @@ class CommitteeCategory(models.Model):
     """
     Category in which a committee can be placed (e.g. Activity committees).
     """
-    name = models.CharField(max_length=50, verbose_name=_('Name'))
+    name = models.CharField(max_length=50, verbose_name=_l('Name'))
     slug = models.SlugField(max_length=50, editable=False)
 
     class Meta(object):
         ordering = ['name']
-        verbose_name = _('committee category')
-        verbose_name_plural = _('committee categories')
+        verbose_name = _l('committee category')
+        verbose_name_plural = _l('committee categories')
 
     def __str__(self):
         return '%s' % self.name
@@ -922,35 +922,35 @@ class Committee(models.Model, Mappable):
     Committee of the association. Members are connected via a Function and if the function changes,
     a *new* Function object is created.
     """
-    name = models.CharField(max_length=100, verbose_name=_('Name'))
-    abbreviation = models.CharField(max_length=20, unique=True, verbose_name=_('Abbreviation'), validators=[
-        RegexValidator(r'^[a-zA-Z0-9.-]*$', _('You can only enter ^[a-zA-Z0-9.-]*$.'), _('Invalid account name')),
+    name = models.CharField(max_length=100, verbose_name=_l('Name'))
+    abbreviation = models.CharField(max_length=20, unique=True, verbose_name=_l('Abbreviation'), validators=[
+        RegexValidator(r'^[a-zA-Z0-9.-]*$', _l('You can only enter ^[a-zA-Z0-9.-]*$.'), _l('Invalid account name')),
         MinLengthValidator(2), MaxLengthValidator(20),
     ])
-    category = models.ForeignKey(CommitteeCategory, null=True, blank=True, verbose_name=_('Category'),
+    category = models.ForeignKey(CommitteeCategory, null=True, blank=True, verbose_name=_l('Category'),
                                  on_delete=models.SET_NULL)
-    parent_committees = models.ManyToManyField('self', blank=True, verbose_name=_('Parent committees'),
+    parent_committees = models.ManyToManyField('self', blank=True, verbose_name=_l('Parent committees'),
                                                symmetrical=False)
 
     slug = models.SlugField(max_length=100, editable=False)
 
-    email = models.EmailField(blank=True, verbose_name=_('E-mail address'))
-    founded = models.DateField(verbose_name=_('Started on'), auto_now_add=True)
-    abolished = models.DateField(null=True, blank=True, verbose_name=_('Ended on'))
-    website = models.URLField(blank=True, verbose_name=_('Web site'))
-    information_nl = models.TextField(verbose_name=_('Information'))
-    information_en = models.TextField(verbose_name=_('Information (en)'))
+    email = models.EmailField(blank=True, verbose_name=_l('E-mail address'))
+    founded = models.DateField(verbose_name=_l('Started on'), auto_now_add=True)
+    abolished = models.DateField(null=True, blank=True, verbose_name=_l('Ended on'))
+    website = models.URLField(blank=True, verbose_name=_l('Web site'))
+    information_nl = models.TextField(verbose_name=_l('Information'))
+    information_en = models.TextField(verbose_name=_l('Information (en)'))
 
-    private_email = models.BooleanField(default=False, verbose_name=_('E-mail address is private'),
-                                        help_text=_(
+    private_email = models.BooleanField(default=False, verbose_name=_l('E-mail address is private'),
+                                        help_text=_l(
                                             'The e-mail address of this committee is not displayed on the website'))
 
-    superuser = models.BooleanField(default=False, verbose_name=_('Is board'),
-                                    help_text=_(
+    superuser = models.BooleanField(default=False, verbose_name=_l('Is board'),
+                                    help_text=_l(
                                         'Members of this committee are granted board authorities on this web site'))
 
-    gitlab = models.BooleanField(default=False, verbose_name=_('Create GitLab group'),
-                                 help_text=_('Members of this committee get access to GitLab'))
+    gitlab = models.BooleanField(default=False, verbose_name=_l('Create GitLab group'),
+                                 help_text=_l('Members of this committee get access to GitLab'))
 
     objects = CommitteeManager()
 
@@ -958,12 +958,12 @@ class Committee(models.Model, Mappable):
 
     group_picture = models.ImageField(upload_to='committeeGroupPictures', null=True, blank=True)
 
-    ledger_account_number = models.CharField(max_length=8, verbose_name=_('ledger account'), default='2500')
+    ledger_account_number = models.CharField(max_length=8, verbose_name=_l('ledger account'), default='2500')
 
     class Meta(object):
         ordering = ['name']
-        verbose_name = _('committee')
-        verbose_name_plural = _('committees')
+        verbose_name = _l('committee')
+        verbose_name_plural = _l('committees')
 
     def __str__(self):
         return '%s' % self.name
@@ -971,7 +971,7 @@ class Committee(models.Model, Mappable):
     def clean(self):
         super(Committee, self).clean()
         if not any(self.email.endswith(domain) for domain in settings.IA_MAIL_DOMAIN):
-            raise ValidationError({'email': _(
+            raise ValidationError({'email': _l(
                 'The email address for a committee may only point to an Inter-Actief server.'
             )})
 
@@ -981,7 +981,7 @@ class Committee(models.Model, Mappable):
 
             # Already in use, if it's us, then it's fine
             if len(Mapping.objects.filter(email=self.email)) > 1 or Mapping.objects.get(email=self.email).get_mapped_object() != self:
-                raise ValidationError({'error': _(
+                raise ValidationError({'error': _l(
                     'This email address is already in use by another mapping!'
                 )})
 
@@ -1087,17 +1087,17 @@ class Function(models.Model):
     Please note that processing properties of this model may be subject to privacy regulations. Refer to
     https://privacy.ia.utwente.nl/ and check whether processing the property is allowed for your purpose.
     """
-    person = models.ForeignKey(Person, verbose_name=_('Person'), on_delete=models.CASCADE)
-    committee = models.ForeignKey(Committee, verbose_name=_('Committee'), on_delete=models.CASCADE)
-    function = models.CharField(max_length=75, verbose_name=_('Position'))
-    note = models.TextField(blank=True, verbose_name=_('Remarks'))
-    begin = models.DateField(verbose_name=_('Started on'))
-    end = models.DateField(null=True, blank=True, verbose_name=_('Ended on'))
+    person = models.ForeignKey(Person, verbose_name=_l('Person'), on_delete=models.CASCADE)
+    committee = models.ForeignKey(Committee, verbose_name=_l('Committee'), on_delete=models.CASCADE)
+    function = models.CharField(max_length=75, verbose_name=_l('Position'))
+    note = models.TextField(blank=True, verbose_name=_l('Remarks'))
+    begin = models.DateField(verbose_name=_l('Started on'))
+    end = models.DateField(null=True, blank=True, verbose_name=_l('Ended on'))
 
     class Meta(object):
         ordering = ['end', '-begin', 'person']
-        verbose_name = _('position')
-        verbose_name_plural = _('functions')
+        verbose_name = _l('position')
+        verbose_name_plural = _l('functions')
 
     def __str__(self):
         return '%s (%s, %s)' % (self.person, self.committee, self.function)
@@ -1106,60 +1106,60 @@ class Function(models.Model):
         if self.pk:
             if not self.end and Function.objects.filter(person=self.person, end=None, committee=self.committee).exclude(
                     id=self.pk).exists():
-                raise ValidationError(_("Person is already a member of this committee."))
+                raise ValidationError(_l("Person is already a member of this committee."))
         else:
             if not self.end and Function.objects.filter(person=self.person, end=None,
                                                         committee=self.committee).exists():
-                raise ValidationError(_("Person is already a member of this committee."))
+                raise ValidationError(_l("Person is already a member of this committee."))
 
                 # save.alters_data = True  # template security
 
 
 class UnverifiedEnrollment(models.Model):
     # Person details
-    first_name = models.CharField(max_length=50, verbose_name=_('First name'))
-    last_name_prefix = models.CharField(max_length=25, blank=True, verbose_name=_('Last name pre-fix'))
-    last_name = models.CharField(max_length=50, verbose_name=_('Last name'))
-    initials = models.CharField(max_length=20, blank=True, verbose_name=_('Initials'))
-    gender = models.CharField(max_length=9, choices=Person.GenderTypes.choices, verbose_name=_('Gender'))
+    first_name = models.CharField(max_length=50, verbose_name=_l('First name'))
+    last_name_prefix = models.CharField(max_length=25, blank=True, verbose_name=_l('Last name pre-fix'))
+    last_name = models.CharField(max_length=50, verbose_name=_l('Last name'))
+    initials = models.CharField(max_length=20, blank=True, verbose_name=_l('Initials'))
+    gender = models.CharField(max_length=9, choices=Person.GenderTypes.choices, verbose_name=_l('Gender'))
     preferred_language = models.CharField(max_length=100, choices=LANGUAGE_CHOICES, default='nl',
-                                          verbose_name=_('Language of preference'))
+                                          verbose_name=_l('Language of preference'))
     international_member = models.CharField(max_length=16, choices=Person.InternationalChoices.choices,
-                                            verbose_name=_("International student"))
-    date_of_birth = models.DateField(null=True, blank=True, verbose_name=_('Birth date'))
-    email_address = models.EmailField(verbose_name=_('E-mail address'), null=True)
-    address = models.CharField(max_length=50, verbose_name=_('Address'))
-    postal_code = models.CharField(max_length=8, verbose_name=_('Postal code'))
-    city = models.CharField(max_length=30, verbose_name=_('City'))
-    country = models.CharField(max_length=25, default='Nederland', verbose_name=_('Country'))
-    telephone = models.CharField(max_length=20, blank=True, verbose_name=_('Phonenumber'))
+                                            verbose_name=_l("International student"))
+    date_of_birth = models.DateField(null=True, blank=True, verbose_name=_l('Birth date'))
+    email_address = models.EmailField(verbose_name=_l('E-mail address'), null=True)
+    address = models.CharField(max_length=50, verbose_name=_l('Address'))
+    postal_code = models.CharField(max_length=8, verbose_name=_l('Postal code'))
+    city = models.CharField(max_length=30, verbose_name=_l('City'))
+    country = models.CharField(max_length=25, default='Nederland', verbose_name=_l('Country'))
+    telephone = models.CharField(max_length=20, blank=True, verbose_name=_l('Phonenumber'))
 
-    email_address_parents = models.EmailField(verbose_name=_('E-mail address of parent(s)/guardian(s)'), blank=True)
-    address_parents = models.CharField(max_length=50, blank=True, verbose_name=_('Address of parent(s)/guardian(s)'))
+    email_address_parents = models.EmailField(verbose_name=_l('E-mail address of parent(s)/guardian(s)'), blank=True)
+    address_parents = models.CharField(max_length=50, blank=True, verbose_name=_l('Address of parent(s)/guardian(s)'))
     postal_code_parents = models.CharField(max_length=8, blank=True,
-                                           verbose_name=_('Postal code of parent(s)/guardian(s)'))
+                                           verbose_name=_l('Postal code of parent(s)/guardian(s)'))
     city_parents = models.CharField(max_length=30, blank=True,
-                                    verbose_name=_('Residence of parent(s)/guardian(s)'))
+                                    verbose_name=_l('Residence of parent(s)/guardian(s)'))
     country_parents = models.CharField(max_length=25, blank=True, default='Nederland',
-                                       verbose_name=_('Country of parent(s)/guardian(s)'))
-    can_use_parents_address = models.BooleanField(default=False, verbose_name=_("My parents' address details may be "
+                                       verbose_name=_l('Country of parent(s)/guardian(s)'))
+    can_use_parents_address = models.BooleanField(default=False, verbose_name=_l("My parents' address details may be "
                                                                                 "used for the parents day."))
-    preferences = models.ManyToManyField(Preference, blank=True, verbose_name=_('Preferences'))
+    preferences = models.ManyToManyField(Preference, blank=True, verbose_name=_l('Preferences'))
 
     # Authorizations that this person wants
-    authorizations = models.ManyToManyField('personal_tab.Authorization', blank=True, verbose_name=_('Authorizations'))
+    authorizations = models.ManyToManyField('personal_tab.Authorization', blank=True, verbose_name=_l('Authorizations'))
 
     # Membership details
-    membership_type = models.ForeignKey(MembershipType, verbose_name=_("Chosen membership type"),
+    membership_type = models.ForeignKey(MembershipType, verbose_name=_l("Chosen membership type"),
                                         on_delete=models.PROTECT)
-    membership_year = models.PositiveIntegerField(verbose_name=_('Membership start year'))
+    membership_year = models.PositiveIntegerField(verbose_name=_l('Membership start year'))
 
     # Student details
-    student_number = models.PositiveIntegerField(verbose_name=_('Student number'), null=True, blank=True, unique=True,
+    student_number = models.PositiveIntegerField(verbose_name=_l('Student number'), null=True, blank=True, unique=True,
                                                  validators=[CheckDigitValidator(7), MaxValueValidator(9999999)])
-    studies = models.ManyToManyField(Study, blank=True, verbose_name=_('Studies'))
-    study_start_date = models.DateField(verbose_name=_('Study start date'))
-    dogroup = models.ForeignKey(DogroupGeneration, null=True, blank=True, verbose_name=_('Dogroup'),
+    studies = models.ManyToManyField(Study, blank=True, verbose_name=_l('Studies'))
+    study_start_date = models.DateField(verbose_name=_l('Study start date'))
+    dogroup = models.ForeignKey(DogroupGeneration, null=True, blank=True, verbose_name=_l('Dogroup'),
                                 on_delete=models.SET_NULL)
 
     def __str__(self):

--- a/amelie/members/query_forms.py
+++ b/amelie/members/query_forms.py
@@ -9,7 +9,7 @@ from django.db.models import Q
 from django.forms import widgets
 from django.template import Template
 from django.utils import translation
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 from functools import reduce
 
 from amelie.api.models import PushNotification
@@ -30,18 +30,18 @@ def _find_years():
 
 class QueryForm(forms.Form):
     name = forms.CharField(max_length=50, required=False, widget=forms.TextInput(attrs={'autofocus': 'autofocus'}))
-    id = forms.IntegerField(required=False, label=_('Amelie-number'))
-    sm_number = forms.CharField(max_length=10, required=False, label=_('S/M number'))
-    phone_number = forms.CharField(max_length=20, required=False, label=_('Phonenumber'))
-    email_address = forms.CharField(max_length=100, required=False, label=_('E-mail address'))
+    id = forms.IntegerField(required=False, label=_l('Amelie-number'))
+    sm_number = forms.CharField(max_length=10, required=False, label=_l('S/M number'))
+    phone_number = forms.CharField(max_length=20, required=False, label=_l('Phonenumber'))
+    email_address = forms.CharField(max_length=100, required=False, label=_l('E-mail address'))
     gender = forms.MultipleChoiceField(required=False, choices=Person.GenderTypes.choices,
                                        widget=widgets.CheckboxSelectMultiple)
-    minor = forms.BooleanField(required=False, label=_('Younger than 18 years old'))
+    minor = forms.BooleanField(required=False, label=_l('Younger than 18 years old'))
 
-    member = forms.BooleanField(required=False, label=_('Return former members'))
-    old_member = forms.BooleanField(required=False, label=_('Only return former members'))
-    paid = forms.BooleanField(required=False, label=_('Has not paid yet'))
-    member_in_year = forms.MultipleChoiceField(required=False, label=_('Was a member in one of these years'))
+    member = forms.BooleanField(required=False, label=_l('Return former members'))
+    old_member = forms.BooleanField(required=False, label=_l('Only return former members'))
+    paid = forms.BooleanField(required=False, label=_l('Has not paid yet'))
+    member_in_year = forms.MultipleChoiceField(required=False, label=_l('Was a member in one of these years'))
 
     study = forms.ModelChoiceField(Study.objects.all(), required=False)
     studies = forms.CharField(max_length=200, required=False)
@@ -52,46 +52,46 @@ class QueryForm(forms.Form):
                                                      widget=widgets.CheckboxSelectMultiple)
 
     preference_not = forms.BooleanField(required=False,
-                                        label=_('Return members who do not have the following options'))
+                                        label=_l('Return members who do not have the following options'))
     preference = forms.ModelMultipleChoiceField(Preference.objects.all(), required=False,
                                                 widget=widgets.CheckboxSelectMultiple)
 
     membership = forms.ModelMultipleChoiceField(MembershipType.objects.all(), required=False)
-    not_verified_membership = forms.BooleanField(required=False, label=_("Membership is not verified"))
-    verified_membership = forms.BooleanField(required=False, label=_("Membership is verified (or not needed for type)"))
+    not_verified_membership = forms.BooleanField(required=False, label=_l("Membership is not verified"))
+    verified_membership = forms.BooleanField(required=False, label=_l("Membership is verified (or not needed for type)"))
 
-    active = forms.BooleanField(required=False, label=_('Is an active member'))
-    not_active = forms.BooleanField(required=False, label=_('Is a not-active member'))
-    has_nda = forms.BooleanField(required=False, label=_('Has signed an NDA'))
-    committee = forms.ModelChoiceField(Committee.objects.all(), required=False, label=_('Once did'))
+    active = forms.BooleanField(required=False, label=_l('Is an active member'))
+    not_active = forms.BooleanField(required=False, label=_l('Is a not-active member'))
+    has_nda = forms.BooleanField(required=False, label=_l('Has signed an NDA'))
+    committee = forms.ModelChoiceField(Committee.objects.all(), required=False, label=_l('Once did'))
     committee_now = forms.ModelChoiceField(Committee.objects.filter(abolished__isnull=True), required=False,
-                                           label=_('Does'))
-    active_year = forms.MultipleChoiceField(choices=(), required=False, label=_('Was active in'))
+                                           label=_l('Does'))
+    active_year = forms.MultipleChoiceField(choices=(), required=False, label=_l('Was active in'))
 
-    employee = forms.BooleanField(required=False, label=_('Member is employee'))
-    department = forms.ModelMultipleChoiceField(Department.objects.all(), required=False, label=_('Belongs to'))
+    employee = forms.BooleanField(required=False, label=_l('Member is employee'))
+    department = forms.ModelMultipleChoiceField(Department.objects.all(), required=False, label=_l('Belongs to'))
 
-    has_dogroup = forms.BooleanField(required=False, label=_('Has a dogroup'))
-    has_no_dogroup = forms.BooleanField(required=False, label=_('Has no dogroup'))
+    has_dogroup = forms.BooleanField(required=False, label=_l('Has a dogroup'))
+    has_no_dogroup = forms.BooleanField(required=False, label=_l('Has no dogroup'))
     dogroup = forms.ModelMultipleChoiceField(DogroupGeneration.objects.all(), required=False)
 
     preferred_language = forms.MultipleChoiceField(choices=LANGUAGE_CHOICES, required=False)
 
     # Mandate
     mandates = forms.ModelMultipleChoiceField(
-        AuthorizationType.objects.all(), required=False, label=_('Mandate'))
-    mandate = forms.IntegerField(required=False, label=_('Mandate number'))
-    iban = forms.CharField(max_length=34, required=False, label=_('IBAN'))
+        AuthorizationType.objects.all(), required=False, label=_l('Mandate'))
+    mandate = forms.IntegerField(required=False, label=_l('Mandate number'))
+    iban = forms.CharField(max_length=34, required=False, label=_l('IBAN'))
 
     # Here are the pre-programmed queries
     # Second/Third/Fourth/Fifth years and older
-    second_year_and_older = forms.BooleanField(required=False, label=_(
+    second_year_and_older = forms.BooleanField(required=False, label=_l(
         'Students in their second year or higher, including all masters (primary studies)'))
-    third_year_and_older = forms.BooleanField(required=False, label=_(
+    third_year_and_older = forms.BooleanField(required=False, label=_l(
         'Students in their third year or higher, including all masters (primary studies)'))
-    fourth_year_and_older = forms.BooleanField(required=False, label=_(
+    fourth_year_and_older = forms.BooleanField(required=False, label=_l(
         'Students in their fourth year or higher, including all masters (primary studies)'))
-    fifth_year_and_older = forms.BooleanField(required=False, label=_(
+    fifth_year_and_older = forms.BooleanField(required=False, label=_l(
         'Students in their fifth year or higher, including all masters (primary studies)'))
 
     def __init__(self, *args, **kwargs):
@@ -107,19 +107,19 @@ class QueryForm(forms.Form):
             try:
                 re.compile(cleaned_data['sm_number'])
             except:
-                raise forms.ValidationError(_("Invalid student or employee number."))
+                raise forms.ValidationError(_l("Invalid student or employee number."))
 
         if cleaned_data.get('iban'):
             try:
                 re.compile(cleaned_data['iban'])
             except:
-                raise forms.ValidationError(_("Invalid IBAN."))
+                raise forms.ValidationError(_l("Invalid IBAN."))
 
         if cleaned_data.get('name'):
             try:
                 re.compile(cleaned_data['name'])
             except:
-                raise forms.ValidationError(_("Invalid characters in name."))
+                raise forms.ValidationError(_l("Invalid characters in name."))
 
         return cleaned_data
 
@@ -379,26 +379,26 @@ class QueryForm(forms.Form):
 
 
 class MailingForm(forms.Form):
-    sender = forms.CharField(label=_('Sender\'s name'), widget=widgets.Input(attrs={'size': 40}))
-    email = forms.EmailField(label=_('Sender\'s e-mail'), widget=widgets.EmailInput(attrs={'size': 50}))
-    cc_email = forms.EmailField(required=False, label=_('CC'), widget=widgets.EmailInput(attrs={'size': 50}))
-    bcc_email = forms.EmailField(required=False, label=_('BCC'), widget=widgets.EmailInput(attrs={'size': 50}))
-    include_waiting_list = forms.BooleanField(label=_('Include people on the waiting list'), required=False)
+    sender = forms.CharField(label=_l('Sender\'s name'), widget=widgets.Input(attrs={'size': 40}))
+    email = forms.EmailField(label=_l('Sender\'s e-mail'), widget=widgets.EmailInput(attrs={'size': 50}))
+    cc_email = forms.EmailField(required=False, label=_l('CC'), widget=widgets.EmailInput(attrs={'size': 50}))
+    bcc_email = forms.EmailField(required=False, label=_l('BCC'), widget=widgets.EmailInput(attrs={'size': 50}))
+    include_waiting_list = forms.BooleanField(label=_l('Include people on the waiting list'), required=False)
 
     subject_nl = forms.CharField(widget=widgets.Input(attrs={'size': 100}))
     subject_en = forms.CharField(widget=widgets.Input(attrs={'size': 100}))
 
     template_nl = forms.CharField(widget=widgets.Textarea(attrs={'class': 'characters', 'rows': '20', 'cols': '90'}),
-                                  label=_('Message (Dutch)'))
+                                  label=_l('Message (Dutch)'))
     template_en = forms.CharField(widget=widgets.Textarea(attrs={'class': 'characters', 'rows': '20', 'cols': '90'}),
-                                  label=_('Message (English)'))
+                                  label=_l('Message (English)'))
 
     def clean_subject(self):
         value = self.cleaned_data['subject']
         try:
             Template(value)
         except Exception:
-            raise forms.ValidationError(_("Invalid subject"))
+            raise forms.ValidationError(_l("Invalid subject"))
         return value
 
     def clean_template(self):
@@ -406,7 +406,7 @@ class MailingForm(forms.Form):
         try:
             Template(value)
         except Exception:
-            raise forms.ValidationError(_("Invalid template"))
+            raise forms.ValidationError(_l("Invalid template"))
         return value
 
     def build_template(self):

--- a/amelie/members/query_views.py
+++ b/amelie/members/query_views.py
@@ -15,7 +15,7 @@ from django.http import HttpResponse, Http404, HttpResponseRedirect, QueryDict
 from django.shortcuts import render, redirect
 from django.template import loader
 from django.views.decorators.cache import never_cache
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.api.models import PushNotification
 from amelie.members.forms import SearchForm
@@ -149,7 +149,7 @@ def send_mailing(request):
             task = form.build_task(persons)
             task.send()
 
-            return render(request, 'message.html', {'message': _(
+            return render(request, 'message.html', {'message': _l(
                 'The mails are now being sent one by one. This happens in a background process and might take a while.'
             )})
 
@@ -191,7 +191,7 @@ class SendNotification(RequireBoardMixin, CreateView):
                                      report_to=self.request.person.email_address,
                                      report_language=self.request.person.preferred_language)
 
-        messages.info(self.request, _(
+        messages.info(self.request, _l(
             'The push notifications are now being sent one by one. This happens in a background process and might '
             'take a while. You will get a delivery report via e-mail when it is complete.'))
 
@@ -222,7 +222,7 @@ class DataExport(RequireBoardMixin, View):
                 return DataExport.email_export(filter_querydict)
             else:
                 # Redirect back to query view with an error message.
-                messages.warning(request, _(
+                messages.warning(request, _l(
                     "Could not make a data export, because an unknown data export type was selected."
                 ))
 
@@ -233,7 +233,7 @@ class DataExport(RequireBoardMixin, View):
 
         else:
             # Redirect back to query view with an error message.
-            messages.warning(request, _(
+            messages.warning(request, _l(
                 "Could not create data export, because something went wrong while saving information about the export."
             ))
             if form.cleaned_data and 'export_details' in form.cleaned_data and form.cleaned_data['export_details']:

--- a/amelie/news/feeds.py
+++ b/amelie/news/feeds.py
@@ -1,13 +1,13 @@
 from django.contrib.syndication.views import Feed
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.news.models import NewsItem
 
 
 class LatestNews(Feed):
-    title = _('IA News')
+    title = _l('IA News')
     link = '/news/'
-    description = _('The news by your favorite Study Association')
+    description = _l('The news by your favorite Study Association')
 
     title_template = "feeds/news_title.html"
     description_template = "feeds/news_content.html"

--- a/amelie/news/forms.py
+++ b/amelie/news/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.news.models import NewsItem
 from amelie.members.models import Committee
@@ -7,10 +7,10 @@ from amelie.members.models import Committee
 
 class NewsItemForm(forms.ModelForm):
 
-    introduction_nl = forms.CharField(max_length=175, label=_('Introduction'), help_text=_('This text can be lay-outed in 175 characters (<a href="https://daringfireball.net/projects/markdown/syntax">markdown</a>)'), widget=forms.Textarea)
-    introduction_en = forms.CharField(max_length=175, label=_('Introduction'), help_text=_('This text can be lay-outed in 175 characters (<a href="https://daringfireball.net/projects/markdown/syntax">markdown</a>)'), widget=forms.Textarea, required=False)
+    introduction_nl = forms.CharField(max_length=175, label=_l('Introduction'), help_text=_l('This text can be lay-outed in 175 characters (<a href="https://daringfireball.net/projects/markdown/syntax">markdown</a>)'), widget=forms.Textarea)
+    introduction_en = forms.CharField(max_length=175, label=_l('Introduction'), help_text=_l('This text can be lay-outed in 175 characters (<a href="https://daringfireball.net/projects/markdown/syntax">markdown</a>)'), widget=forms.Textarea, required=False)
 #    content = forms.CharField(label=_('Content'), widget=TextEditor)
-    publisher = forms.ModelChoiceField(Committee.objects.all(), label=_('Publisher'))
+    publisher = forms.ModelChoiceField(Committee.objects.all(), label=_l('Publisher'))
 
     class Meta:
         model = NewsItem

--- a/amelie/news/models.py
+++ b/amelie/news/models.py
@@ -3,7 +3,7 @@ from django.db import models
 from django.db.models.signals import post_save
 from django.template.defaultfilters import slugify
 from django.utils.translation import get_language
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.activities.models import Activity
 from amelie.files.models import Attachment
@@ -32,12 +32,12 @@ class NewsItem(models.Model):
     attachments = models.ManyToManyField(Attachment, blank=True)
     activities = models.ManyToManyField(Activity, blank=True)
 
-    pinned = models.BooleanField(default=False, help_text=_('Choose this option to pin the news item'))
+    pinned = models.BooleanField(default=False, help_text=_l('Choose this option to pin the news item'))
 
     class Meta:
         ordering = ['-publication_date']
-        verbose_name = _('News message')
-        verbose_name_plural = _('News messages')
+        verbose_name = _l('News message')
+        verbose_name_plural = _l('News messages')
 
     def __str__(self):
         return '%s' % self.title

--- a/amelie/oauth/forms.py
+++ b/amelie/oauth/forms.py
@@ -1,12 +1,12 @@
 from django import forms
 from django.forms import widgets
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _l
 
 
 class OAuth2RequestForm(forms.Form):
-    application_name = forms.CharField(max_length=50, label=_('The application that will use the OAuth key'))
-    member_name = forms.CharField(max_length=50, label=_('The name of the member requesting OAuth access'))
-    member_mail = forms.CharField(label=_('The email of the member requesting OAuth access'), widget=widgets.EmailInput)
-    redirect_urls = forms.CharField(max_length=500, widget=widgets.Textarea, label=_('A list with on each line a redirect URL'))
-    client_type = forms.ChoiceField(choices=(('confidential', _("Confidential")), ('public', _("Public"))), widget=widgets.RadioSelect)
-    description = forms.CharField(max_length=250, label=_('A short description of the intended purpose of the application'))
+    application_name = forms.CharField(max_length=50, label=_l('The application that will use the OAuth key'))
+    member_name = forms.CharField(max_length=50, label=_l('The name of the member requesting OAuth access'))
+    member_mail = forms.CharField(label=_l('The email of the member requesting OAuth access'), widget=widgets.EmailInput)
+    redirect_urls = forms.CharField(max_length=500, widget=widgets.Textarea, label=_l('A list with on each line a redirect URL'))
+    client_type = forms.ChoiceField(choices=(('confidential', _l("Confidential")), ('public', _l("Public"))), widget=widgets.RadioSelect)
+    description = forms.CharField(max_length=250, label=_l('A short description of the intended purpose of the application'))

--- a/amelie/personal_tab/forms.py
+++ b/amelie/personal_tab/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.conf import settings
 from django.db.models import TextChoices
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 from localflavor.generic.forms import BICFormField, IBANFormField
 
 from amelie.style.forms import inject_style
@@ -13,7 +13,7 @@ from amelie.tools.widgets import DateSelector, DateTimeSelector, MemberSelect
 
 
 class CustomTransactionForm(forms.ModelForm):
-    date = forms.SplitDateTimeField(label=_('Date'), widget=DateTimeSelector, initial=timezone.now)
+    date = forms.SplitDateTimeField(label=_l('Date'), widget=DateTimeSelector, initial=timezone.now)
 
     class Meta:
         model = CustomTransaction
@@ -21,7 +21,7 @@ class CustomTransactionForm(forms.ModelForm):
 
 
 class CookieCornerTransactionForm(forms.ModelForm):
-    date = forms.SplitDateTimeField(label=_('Date'), widget=DateTimeSelector, initial=timezone.now)
+    date = forms.SplitDateTimeField(label=_l('Date'), widget=DateTimeSelector, initial=timezone.now)
 
     class Meta:
         model = CookieCornerTransaction
@@ -29,16 +29,16 @@ class CookieCornerTransactionForm(forms.ModelForm):
 
 
 class ExamCookieCreditForm(forms.Form):
-    price = forms.DecimalField(max_digits=8, decimal_places=2, label=_('Price'))
-    description = forms.CharField(max_length=200, label=_('Description'))
+    price = forms.DecimalField(max_digits=8, decimal_places=2, label=_l('Price'))
+    description = forms.CharField(max_length=200, label=_l('Description'))
 
 
 class DebtCollectionForm(forms.Form):
-    description = forms.CharField(max_length=50, label=_('Description for within Inter-Actief'))
-    execution_date = forms.DateField(label=_('Date of execution'), widget=DateSelector)
-    contribution = forms.BooleanField(required=False, label=_('Membership fee'))
-    cookie_corner = forms.BooleanField(required=False, label=_('Personal tab'))
-    end = forms.SplitDateTimeField(label=_('Transactions until'), widget=DateTimeSelector)
+    description = forms.CharField(max_length=50, label=_l('Description for within Inter-Actief'))
+    execution_date = forms.DateField(label=_l('Date of execution'), widget=DateSelector)
+    contribution = forms.BooleanField(required=False, label=_l('Membership fee'))
+    cookie_corner = forms.BooleanField(required=False, label=_l('Personal tab'))
+    end = forms.SplitDateTimeField(label=_l('Transactions until'), widget=DateTimeSelector)
 
     def __init__(self, minimal_execution_date, *args, **kwargs):
         super(DebtCollectionForm, self).__init__(*args, **kwargs)
@@ -48,9 +48,9 @@ class DebtCollectionForm(forms.Form):
     def clean_execution_date(self):
         data = self.cleaned_data['execution_date']
         if data < self.minimal_execution_date:
-            raise forms.ValidationError(_('Date of execution is too soon'))
+            raise forms.ValidationError(_l('Date of execution is too soon'))
         if data.weekday() >= 5:  # Saturday or sunday
-            raise forms.ValidationError(_('Date of execution cannot be during the weekend'))
+            raise forms.ValidationError(_l('Date of execution cannot be during the weekend'))
 
         # Always return the cleaned data, whether you have changed it or not.
         return data
@@ -72,17 +72,17 @@ class AmendmentForm(forms.Form):
     """Form to enter an amendment"""
 
     """Date of the amendment"""
-    date = forms.DateField(label=_('Date'))
+    date = forms.DateField(label=_l('Date'))
 
     """IBAN for authorization"""
-    iban = IBANFormField(label=_('IBAN'))
+    iban = IBANFormField(label=_l('IBAN'))
 
     """BIC for authorization"""
-    bic = BICFormField(label=_('BIC*'), required=False)
+    bic = BICFormField(label=_l('BIC*'), required=False)
 
     """Short description of the reason of this amendment."""
-    reason = forms.CharField(max_length=250, label=_('Remarks'),
-                             help_text=_('Short description of the reason for the amendment'))
+    reason = forms.CharField(max_length=250, label=_l('Remarks'),
+                             help_text=_l('Short description of the reason for the amendment'))
 
     def clean(self):
         cleaned_data = super(AmendmentForm, self).clean()
@@ -92,11 +92,11 @@ class AmendmentForm(forms.Form):
 
         if not cleaned_data['bic']:
             if not cleaned_data['iban'][:2] == 'NL':
-                self.add_error('bic', _('BIC has to be entered for foreign bank accounts.'))
+                self.add_error('bic', _l('BIC has to be entered for foreign bank accounts.'))
             elif cleaned_data['iban'][4:8] in settings.COOKIE_CORNER_BANK_CODES:
                 cleaned_data['bic'] = settings.COOKIE_CORNER_BANK_CODES[cleaned_data['iban'][4:8]]
             else:
-                self.add_error('bic', _('BIC could not be generated, please enter yourself.'))
+                self.add_error('bic', _l('BIC could not be generated, please enter yourself.'))
         return cleaned_data
 
 
@@ -106,28 +106,28 @@ inject_style(CustomTransactionForm, CookieCornerTransactionForm, ExamCookieCredi
 
 class SearchAuthorizationForm(forms.Form):
     class AuthorizationStatuses(TextChoices):
-        UNSIGNED = 'unsigned', _("Not signed")
-        ACTIVE = 'active', _("Active")
-        TERMINATED = 'terminated', _("Ended")
+        UNSIGNED = 'unsigned', _l("Not signed")
+        ACTIVE = 'active', _l("Active")
+        TERMINATED = 'terminated', _l("Ended")
 
     class SortOptions(TextChoices):
-        PERSON = 'person', _('Person')
-        ID = 'id', _('Reference')
-        AUTHORIZATION_TYPE = 'authorization_type', _('Type')
-        ACCOUNT_HOLDER_NAME = 'account_holder_name', _('Account holder')
-        IBAN = 'iban', _('IBAN')
-        BIC = 'bic', _('BIC')
-        START_DATE = 'start_date', _('Starts on')
-        END_DATE = 'end_date', _('Ends on')
+        PERSON = 'person', _l('Person')
+        ID = 'id', _l('Reference')
+        AUTHORIZATION_TYPE = 'authorization_type', _l('Type')
+        ACCOUNT_HOLDER_NAME = 'account_holder_name', _l('Account holder')
+        IBAN = 'iban', _l('IBAN')
+        BIC = 'bic', _l('BIC')
+        START_DATE = 'start_date', _l('Starts on')
+        END_DATE = 'end_date', _l('Ends on')
 
-    search = forms.CharField(required=False, label=_('Search'))
+    search = forms.CharField(required=False, label=_l('Search'))
     status = forms.MultipleChoiceField(required=False, choices=AuthorizationStatuses.choices,
-                                       widget=forms.CheckboxSelectMultiple, label=_('Status'))
+                                       widget=forms.CheckboxSelectMultiple, label=_l('Status'))
     authorization_type = forms.ModelMultipleChoiceField(required=False, queryset=AuthorizationType.objects.all(),
-                                                        widget=forms.CheckboxSelectMultiple, label=_('Sort'))
+                                                        widget=forms.CheckboxSelectMultiple, label=_l('Sort'))
     sort_by = forms.ChoiceField(required=False, choices=SortOptions.choices, initial=SortOptions.PERSON.value,
-                                label=_('Sort by'))
-    reverse = forms.BooleanField(required=False, initial=False, label=_('Sort in reverse'))
+                                label=_l('Sort by'))
+    reverse = forms.BooleanField(required=False, initial=False, label=_l('Sort in reverse'))
 
 
 class RFIDCardForm(forms.ModelForm):
@@ -145,7 +145,7 @@ class RFIDCardForm(forms.ModelForm):
 
 class AuthorizationSelectForm(forms.Form):
     authorizations = forms.ModelMultipleChoiceField(queryset=Authorization.objects.all(),
-                                                    widget=forms.CheckboxSelectMultiple, label=_('Mandates'))
+                                                    widget=forms.CheckboxSelectMultiple, label=_l('Mandates'))
 
     def __init__(self, authorizations_queryset, *args, **kwargs):
         super(AuthorizationSelectForm, self).__init__(*args, **kwargs)
@@ -154,9 +154,9 @@ class AuthorizationSelectForm(forms.Form):
 
 
 class StatisticsForm(forms.Form):
-    start_date = forms.SplitDateTimeField(label=_('Beginning:'), widget=DateTimeSelector, required=True)
-    end_date = forms.SplitDateTimeField(label=_('End (till)'), widget=DateTimeSelector, required=True)
-    checkboxes = forms.MultipleChoiceField(label=_('Tables:'), widget=forms.CheckboxSelectMultiple(), required=False)
+    start_date = forms.SplitDateTimeField(label=_l('Beginning:'), widget=DateTimeSelector, required=True)
+    end_date = forms.SplitDateTimeField(label=_l('End (till)'), widget=DateTimeSelector, required=True)
+    checkboxes = forms.MultipleChoiceField(label=_l('Tables:'), widget=forms.CheckboxSelectMultiple(), required=False)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -164,8 +164,8 @@ class StatisticsForm(forms.Form):
 
 
 class CookieCornerPersonSearchForm(forms.Form):
-    person = forms.IntegerField(widget=MemberSelect(attrs={'autofocus': 'autofocus', 'placeholder': _('Find person')}),
-                                label=_('Person'), error_messages={'required': _('Choose a name from the suggestions.')})
+    person = forms.IntegerField(widget=MemberSelect(attrs={'autofocus': 'autofocus', 'placeholder': _l('Find person')}),
+                                label=_l('Person'), error_messages={'required': _l('Choose a name from the suggestions.')})
 
 
 inject_style(StatisticsForm)

--- a/amelie/personal_tab/models.py
+++ b/amelie/personal_tab/models.py
@@ -7,7 +7,7 @@ from django.db import models
 from django.db.models import Q
 from django.db.models.signals import pre_save, post_save, post_delete
 from django.utils import timezone
-from django.utils.translation import get_language, gettext_lazy as _
+from django.utils.translation import get_language, gettext_lazy as _l
 from localflavor.generic.models import BICField, IBANField
 
 from amelie.claudia.tools import verify_instance
@@ -16,14 +16,14 @@ from amelie.personal_tab.managers import AuthorizationManager, DebtCollectionIns
 
 
 class DiscountPeriod(models.Model):
-    begin = models.DateTimeField(blank=False, verbose_name=_('begin'))
-    end = models.DateTimeField(blank=True, null=True, verbose_name=_('end'))
-    description_nl = models.CharField(max_length=200, blank=False, verbose_name=_('description'))
-    description_en = models.CharField(max_length=200, blank=True, verbose_name=_('description (en)'))
+    begin = models.DateTimeField(blank=False, verbose_name=_l('begin'))
+    end = models.DateTimeField(blank=True, null=True, verbose_name=_l('end'))
+    description_nl = models.CharField(max_length=200, blank=False, verbose_name=_l('description'))
+    description_en = models.CharField(max_length=200, blank=True, verbose_name=_l('description (en)'))
     articles = models.ManyToManyField('Article', related_name='discount_periods', blank=True,
-                                      verbose_name=_('articles'))
-    ledger_account_number = models.CharField(max_length=8, verbose_name=_('ledger account'), default='2500')
-    balance_account_number = models.CharField(max_length=8, verbose_name=_('balance account number'), default='2500')
+                                      verbose_name=_l('articles'))
+    ledger_account_number = models.CharField(max_length=8, verbose_name=_l('ledger account'), default='2500')
+    balance_account_number = models.CharField(max_length=8, verbose_name=_l('balance account number'), default='2500')
 
     @property
     def description(self):
@@ -39,23 +39,23 @@ class DiscountPeriod(models.Model):
 
     class Meta:
         ordering = ['-begin', '-end']
-        verbose_name = _('discount offer')
-        verbose_name_plural = _("discount offers")
+        verbose_name = _l('discount offer')
+        verbose_name_plural = _l("discount offers")
 
 
 class Discount(models.Model):
-    amount = models.DecimalField(max_digits=8, decimal_places=2, default=0.00, verbose_name=_('amount'))
-    date = models.DateTimeField(auto_now_add=True, verbose_name=_('date'))
+    amount = models.DecimalField(max_digits=8, decimal_places=2, default=0.00, verbose_name=_l('amount'))
+    date = models.DateTimeField(auto_now_add=True, verbose_name=_l('date'))
     discount_period = models.ForeignKey(DiscountPeriod, blank=False, on_delete=models.PROTECT,
-                                        verbose_name=_('discount offer'))
+                                        verbose_name=_l('discount offer'))
 
     def __str__(self):
         return '{} ({})'.format(self.discount_period.description, self.amount)
 
     class Meta:
         ordering = ['-date']
-        verbose_name = _('discount')
-        verbose_name_plural = _("discounts")
+        verbose_name = _l('discount')
+        verbose_name_plural = _l("discounts")
 
 
 class DiscountCredit(models.Model):
@@ -77,22 +77,22 @@ class DiscountCredit(models.Model):
     added_by:           The person that created this object.
     """
 
-    discount_period = models.ForeignKey(DiscountPeriod, on_delete=models.PROTECT, verbose_name=_('discount offer'))
-    date = models.DateTimeField(default=timezone.now, verbose_name=_('date'))
-    price = models.DecimalField(max_digits=8, decimal_places=2, default=0.00, verbose_name=_('amount'))
-    person = models.ForeignKey(Person, verbose_name=_('person'), on_delete=models.PROTECT)
-    description = models.CharField(max_length=200, blank=True, verbose_name=_('description'))
-    discount = models.OneToOneField(Discount, blank=True, null=True, default=None, verbose_name=_('discount'), on_delete=models.PROTECT)
+    discount_period = models.ForeignKey(DiscountPeriod, on_delete=models.PROTECT, verbose_name=_l('discount offer'))
+    date = models.DateTimeField(default=timezone.now, verbose_name=_l('date'))
+    price = models.DecimalField(max_digits=8, decimal_places=2, default=0.00, verbose_name=_l('amount'))
+    person = models.ForeignKey(Person, verbose_name=_l('person'), on_delete=models.PROTECT)
+    description = models.CharField(max_length=200, blank=True, verbose_name=_l('description'))
+    discount = models.OneToOneField(Discount, blank=True, null=True, default=None, verbose_name=_l('discount'), on_delete=models.PROTECT)
 
-    added_on = models.DateTimeField(verbose_name=_('added on'), auto_now_add=True)
+    added_on = models.DateTimeField(verbose_name=_l('added on'), auto_now_add=True)
 
     # '+' related_name makes sure no reverse relation is added to Person
-    added_by = models.ForeignKey(Person, blank=True, null=True, related_name="+", verbose_name=_('added by'), on_delete=models.PROTECT)
+    added_by = models.ForeignKey(Person, blank=True, null=True, related_name="+", verbose_name=_l('added by'), on_delete=models.PROTECT)
 
     class Meta:
         ordering = ['-date', '-added_on']
-        verbose_name = _('Discount balance')
-        verbose_name_plural = _("discount balances")
+        verbose_name = _l('Discount balance')
+        verbose_name_plural = _l("discount balances")
 
     def __str__(self):
         return '{} ({})'.format(self.description, self.price)
@@ -118,24 +118,24 @@ class Transaction(models.Model):
     added_by:           The person that created this object.
     """
 
-    date = models.DateTimeField(default=timezone.now, verbose_name=_('Date'))
-    price = models.DecimalField(max_digits=8, decimal_places=2, default=0.00, verbose_name=_('Price'))
-    person = models.ForeignKey(Person, verbose_name=_('Person'), on_delete=models.PROTECT)
-    description = models.CharField(max_length=200, blank=True, verbose_name=_('Description'))
-    discount = models.OneToOneField(Discount, blank=True, null=True, default=None, verbose_name=_('discount'), on_delete=models.PROTECT)
+    date = models.DateTimeField(default=timezone.now, verbose_name=_l('Date'))
+    price = models.DecimalField(max_digits=8, decimal_places=2, default=0.00, verbose_name=_l('Price'))
+    person = models.ForeignKey(Person, verbose_name=_l('Person'), on_delete=models.PROTECT)
+    description = models.CharField(max_length=200, blank=True, verbose_name=_l('Description'))
+    discount = models.OneToOneField(Discount, blank=True, null=True, default=None, verbose_name=_l('discount'), on_delete=models.PROTECT)
 
-    debt_collection = models.ForeignKey('DebtCollectionInstruction', verbose_name=_('Direct withdrawal'), blank=True, null=True,
+    debt_collection = models.ForeignKey('DebtCollectionInstruction', verbose_name=_l('Direct withdrawal'), blank=True, null=True,
                                         related_name="transactions", on_delete=models.PROTECT)
 
-    added_on = models.DateTimeField(verbose_name=_('Added on'), auto_now_add=True)
+    added_on = models.DateTimeField(verbose_name=_l('Added on'), auto_now_add=True)
 
     # '+' related_name makes sure no reverse relation is added to Person
-    added_by = models.ForeignKey(Person, verbose_name=_('Added by'), blank=True, null=True, related_name="+", on_delete=models.PROTECT)
+    added_by = models.ForeignKey(Person, verbose_name=_l('Added by'), blank=True, null=True, related_name="+", on_delete=models.PROTECT)
 
     class Meta:
         ordering = ['-date', '-added_on']
-        verbose_name = _('Transaction')
-        verbose_name_plural = _("Transactions")
+        verbose_name = _l('Transaction')
+        verbose_name_plural = _l("Transactions")
 
     def get_absolute_url(self):
         return reverse('personal_tab:transaction_detail', args=[self.pk])
@@ -176,10 +176,10 @@ class ActivityTransaction(Transaction):
     with_enrollment_options:    If the Participation has any enrollment options that might cost extra.
     """
 
-    event = models.ForeignKey('calendar.Event', verbose_name=_('Activities'), null=True, on_delete=models.SET_NULL)
+    event = models.ForeignKey('calendar.Event', verbose_name=_l('Activities'), null=True, on_delete=models.SET_NULL)
     participation = models.ForeignKey('calendar.Participation', null=True, on_delete=models.SET_NULL,
-                                      verbose_name=_('Enrollment'))
-    with_enrollment_options = models.BooleanField(verbose_name=_('More sign up options'), default=False)
+                                      verbose_name=_l('Enrollment'))
+    with_enrollment_options = models.BooleanField(verbose_name=_l('More sign up options'), default=False)
 
     def get_absolute_url(self):
         return reverse('personal_tab:activity_transaction_detail', args=[self.pk])
@@ -196,8 +196,8 @@ class CookieCornerTransaction(Transaction):
     amount: The amount of this Article that were bought.
     """
 
-    article = models.ForeignKey('Article', verbose_name=_('Article'), null=True, on_delete=models.SET_NULL)
-    amount = models.PositiveIntegerField(verbose_name=_('Amount'))
+    article = models.ForeignKey('Article', verbose_name=_l('Article'), null=True, on_delete=models.SET_NULL)
+    amount = models.PositiveIntegerField(verbose_name=_l('Amount'))
 
     def kcal(self):
         if self.article.kcal is not None:
@@ -221,7 +221,7 @@ class AlexiaTransaction(Transaction):
     transaction_id: The transaction ID of the transaction in Alexia.
     """
 
-    transaction_id = models.PositiveIntegerField(verbose_name=_('Transaction id'))
+    transaction_id = models.PositiveIntegerField(verbose_name=_l('Transaction id'))
 
     def get_absolute_url(self):
         return reverse('personal_tab:alexia_transaction_detail', args=[self.pk])
@@ -237,7 +237,7 @@ class ContributionTransaction(Transaction):
     membership: The Membership object that is being paid with this transaction.
     """
 
-    membership = models.ForeignKey(Membership, verbose_name=_('Membership'), on_delete=models.PROTECT)
+    membership = models.ForeignKey(Membership, verbose_name=_l('Membership'), on_delete=models.PROTECT)
 
 
 class LedgerAccount(models.Model):
@@ -250,16 +250,16 @@ class LedgerAccount(models.Model):
     ledger_account_number:  The ledger account number of this article.
     """
 
-    name = models.CharField(max_length=50, verbose_name=_('Name'))
+    name = models.CharField(max_length=50, verbose_name=_l('Name'))
 
-    ledger_account_number = models.CharField(max_length=8, verbose_name=_('ledger account'), default='2500')
+    ledger_account_number = models.CharField(max_length=8, verbose_name=_l('ledger account'), default='2500')
 
     default_statistics = models.BooleanField(default=False)
 
     class Meta:
         ordering = ['name']
-        verbose_name = _('General ledger account')
-        verbose_name_plural = _("General ledger accounts")
+        verbose_name = _l('General ledger account')
+        verbose_name_plural = _l("General ledger accounts")
 
     def __str__(self):
         return '{}'.format(self.name)
@@ -278,15 +278,15 @@ class Article(models.Model):
     kcal: The amount of kiloCalories this product has. This is used in statistics. Optional.
     """
 
-    name_nl = models.CharField(max_length=50, verbose_name=_('Name'))
-    name_en = models.CharField(max_length=50, verbose_name=_('Name (en)'))
-    category = models.ForeignKey('Category', verbose_name=_('Category'), on_delete=models.PROTECT)
-    ledger_account = models.ForeignKey(LedgerAccount, verbose_name=_('General ledger account'), blank=True, null=True,
+    name_nl = models.CharField(max_length=50, verbose_name=_l('Name'))
+    name_en = models.CharField(max_length=50, verbose_name=_l('Name (en)'))
+    category = models.ForeignKey('Category', verbose_name=_l('Category'), on_delete=models.PROTECT)
+    ledger_account = models.ForeignKey(LedgerAccount, verbose_name=_l('General ledger account'), blank=True, null=True,
                                        on_delete=models.SET_NULL, related_name='articles')
-    price = models.DecimalField(max_digits=8, decimal_places=2, verbose_name=_('Price'))
-    is_available = models.BooleanField(default=False, verbose_name=_('Available'))
-    image = models.ImageField(upload_to='cookie_corner', max_length=255, blank=False, verbose_name=_('Image'))
-    kcal = models.PositiveSmallIntegerField(verbose_name=_('kCal'), blank=True, null=True)
+    price = models.DecimalField(max_digits=8, decimal_places=2, verbose_name=_l('Price'))
+    is_available = models.BooleanField(default=False, verbose_name=_l('Available'))
+    image = models.ImageField(upload_to='cookie_corner', max_length=255, blank=False, verbose_name=_l('Image'))
+    kcal = models.PositiveSmallIntegerField(verbose_name=_l('kCal'), blank=True, null=True)
 
     @property
     def name(self):
@@ -299,8 +299,8 @@ class Article(models.Model):
 
     class Meta:
         ordering = ['name_nl']
-        verbose_name = _('Article')
-        verbose_name_plural = _("Articles")
+        verbose_name = _l('Article')
+        verbose_name_plural = _l("Articles")
 
     def __str__(self):
         return '{}'.format(self.name)
@@ -316,13 +316,13 @@ class Category(models.Model):
     order: Integer indicating the order this category should be shown in. 1 will be shown before 2, etc.
     """
 
-    name_nl = models.CharField(max_length=50, verbose_name=_('Name'))
-    name_en = models.CharField(max_length=50, verbose_name=_('Name (en)'))
-    is_available = models.BooleanField(default=False, verbose_name=_('Available'))
-    image = models.ImageField(upload_to='cookie_corner', max_length=255, blank=True, verbose_name=_('Image'))
-    order = models.PositiveIntegerField(default=0, null=False, verbose_name=_('Sequence'))
-    show_calculator_in_pos = models.BooleanField(default=False, verbose_name=_('Show the calculator in the Point of Sale instead of the products'),
-                                                 help_text=_('The first active article in the category will be used for calculations.'))
+    name_nl = models.CharField(max_length=50, verbose_name=_l('Name'))
+    name_en = models.CharField(max_length=50, verbose_name=_l('Name (en)'))
+    is_available = models.BooleanField(default=False, verbose_name=_l('Available'))
+    image = models.ImageField(upload_to='cookie_corner', max_length=255, blank=True, verbose_name=_l('Image'))
+    order = models.PositiveIntegerField(default=0, null=False, verbose_name=_l('Sequence'))
+    show_calculator_in_pos = models.BooleanField(default=False, verbose_name=_l('Show the calculator in the Point of Sale instead of the products'),
+                                                 help_text=_l('The first active article in the category will be used for calculations.'))
 
     @property
     def name(self):
@@ -338,8 +338,8 @@ class Category(models.Model):
 
     class Meta:
         ordering = ['order', 'name_nl']
-        verbose_name = _('Category')
-        verbose_name_plural = _('Categories')
+        verbose_name = _l('Category')
+        verbose_name_plural = _l('Categories')
 
     def __str__(self):
         return '{}'.format(self.name)
@@ -355,29 +355,29 @@ class RFIDCard(models.Model):
     # RFID types
     # Source: API Driver Manual of ACR120U Contactless Smart Card Reader
     # https://www.acs.com.hk/download-manual/428/API_ACR120U_v3.00.pdf
-    TYPES = {'01': _('Mifare Light'),
-             '02': _('Mifare 1K (Student card/Building card)'),
-             '03': _('Mifare 4K (Public transit card)'),
-             '04': _('Mifare DESFire'),
-             '05': _('Mifare Ultralight (student card)'),
-             '06': _('JCOP30'),
-             '07': _('Shanghai Transport'),
-             '08': _('MPCOS Combi'),
-             '80': _('ISO Type B, Calypso'),
-             '81': _('ASK CTS256B, Type B'),
-             '82': _('ASK CTS521B, Type B'),
+    TYPES = {'01': _l('Mifare Light'),
+             '02': _l('Mifare 1K (Student card/Building card)'),
+             '03': _l('Mifare 4K (Public transit card)'),
+             '04': _l('Mifare DESFire'),
+             '05': _l('Mifare Ultralight (student card)'),
+             '06': _l('JCOP30'),
+             '07': _l('Shanghai Transport'),
+             '08': _l('MPCOS Combi'),
+             '80': _l('ISO Type B, Calypso'),
+             '81': _l('ASK CTS256B, Type B'),
+             '82': _l('ASK CTS521B, Type B'),
              }
 
-    person = models.ForeignKey(Person, verbose_name=_('Person'), on_delete=models.CASCADE)
-    code = models.CharField(max_length=50, unique=True, verbose_name=_('Rfid code'))
-    active = models.BooleanField(default=False, verbose_name=_('Activated'))
-    last_used = models.DateTimeField(auto_now_add=True, null=True, verbose_name=_('Date last used'))
-    created = models.DateTimeField(auto_now_add=True, null=True, verbose_name=_('Creation date'))
+    person = models.ForeignKey(Person, verbose_name=_l('Person'), on_delete=models.CASCADE)
+    code = models.CharField(max_length=50, unique=True, verbose_name=_l('Rfid code'))
+    active = models.BooleanField(default=False, verbose_name=_l('Activated'))
+    last_used = models.DateTimeField(auto_now_add=True, null=True, verbose_name=_l('Date last used'))
+    created = models.DateTimeField(auto_now_add=True, null=True, verbose_name=_l('Creation date'))
 
     class Meta:
         ordering = ['code']
-        verbose_name = _('RFID card')
-        verbose_name_plural = _('RFID cards')
+        verbose_name = _l('RFID card')
+        verbose_name_plural = _l('RFID cards')
 
     def __str__(self):
         if self.code[:3] == '02,':
@@ -411,38 +411,38 @@ class RFIDCard(models.Model):
 
 
 SEPA_CHAR_VALIDATOR = RegexValidator(regex=r'^[a-zA-Z0-9-?:().,\'+ ]*$',
-                                     message=_('Only alphanumerical signs are allowed'))
+                                     message=_l('Only alphanumerical signs are allowed'))
 
 
 class AuthorizationType(models.Model):
     """A kind of Authorization"""
 
     """Name of the authorization (Dutch)"""
-    name_nl = models.CharField(max_length=50, verbose_name=_('name'))
+    name_nl = models.CharField(max_length=50, verbose_name=_l('name'))
 
     """Name of the authorization (English)"""
-    name_en = models.CharField(blank=True, max_length=50, verbose_name=_('name (en)'))
+    name_en = models.CharField(blank=True, max_length=50, verbose_name=_l('name (en)'))
 
     """Short description of the authorization (Dutch)"""
-    text_nl = models.TextField(verbose_name=_('text'))
+    text_nl = models.TextField(verbose_name=_l('text'))
 
     """Short description of the authorization (English)"""
-    text_en = models.TextField(blank=True, verbose_name=_('text (en)'))
+    text_en = models.TextField(blank=True, verbose_name=_l('text (en)'))
 
     """An authorization of this type may be newly created and signed."""
-    active = models.BooleanField(default=False, verbose_name=_('active'))
+    active = models.BooleanField(default=False, verbose_name=_l('active'))
 
     """Contribution payments may be collected using this authorization."""
-    contribution = models.BooleanField(default=False, verbose_name=_('membership fee'))
+    contribution = models.BooleanField(default=False, verbose_name=_l('membership fee'))
 
     """Consumption payments may be collected using this authorization."""
-    consumptions = models.BooleanField(default=False, verbose_name=_('consumptions'))
+    consumptions = models.BooleanField(default=False, verbose_name=_l('consumptions'))
 
     """Activity payments may be collected using this authorization."""
-    activities = models.BooleanField(default=False, verbose_name=_('activities'))
+    activities = models.BooleanField(default=False, verbose_name=_l('activities'))
 
     """Other payments may be collected using this authorization."""
-    other_payments = models.BooleanField(default=False, verbose_name=_('other payments'))
+    other_payments = models.BooleanField(default=False, verbose_name=_l('other payments'))
 
     @property
     def name(self):
@@ -467,8 +467,8 @@ class AuthorizationType(models.Model):
 
     class Meta:
         ordering = ['name_nl']
-        verbose_name = _('type of mandate')
-        verbose_name_plural = _('types of mandate')
+        verbose_name = _l('type of mandate')
+        verbose_name_plural = _l('types of mandate')
 
 
 class Authorization(models.Model):
@@ -482,29 +482,29 @@ class Authorization(models.Model):
     PREFIX = 'IA-MNDT-'
 
     """Type of authorization"""
-    authorization_type = models.ForeignKey(AuthorizationType, on_delete=models.PROTECT, verbose_name=_('type'))
+    authorization_type = models.ForeignKey(AuthorizationType, on_delete=models.PROTECT, verbose_name=_l('type'))
 
     """Person that gave the authorization"""
-    person = models.ForeignKey(Person, verbose_name=_('person'), null=True, blank=True, on_delete=models.PROTECT)
+    person = models.ForeignKey(Person, verbose_name=_l('person'), null=True, blank=True, on_delete=models.PROTECT)
 
     """IBAN for authorization"""
-    iban = IBANField(verbose_name=_('IBAN'), blank=True)
+    iban = IBANField(verbose_name=_l('IBAN'), blank=True)
 
     """BIC for authorization"""
-    bic = BICField(verbose_name=_('BIC'), blank=True)
+    bic = BICField(verbose_name=_l('BIC'), blank=True)
 
     """Name of the account holder"""
-    account_holder_name = models.CharField(max_length=70, verbose_name=_('account holder'),
+    account_holder_name = models.CharField(max_length=70, verbose_name=_l('account holder'),
                                            validators=[SEPA_CHAR_VALIDATOR], blank=True)
 
     """Start date of the authorization"""
-    start_date = models.DateField(verbose_name=_('startdate'))
+    start_date = models.DateField(verbose_name=_l('startdate'))
 
     """End date of the authorization, is None if the authorization has not ended yet."""
-    end_date = models.DateField(verbose_name=_('enddate'), null=True, blank=True)
+    end_date = models.DateField(verbose_name=_l('enddate'), null=True, blank=True)
 
     """This authorization has been signed"""
-    is_signed = models.BooleanField(default=False, verbose_name=_('has been signed'))
+    is_signed = models.BooleanField(default=False, verbose_name=_l('has been signed'))
 
     objects = AuthorizationManager()
 
@@ -585,8 +585,8 @@ class Authorization(models.Model):
 
     class Meta:
         ordering = ['person', 'start_date']
-        verbose_name = _('mandate')
-        verbose_name_plural = _('mandates')
+        verbose_name = _l('mandate')
+        verbose_name_plural = _l('mandates')
 
 
 class Amendment(models.Model):
@@ -598,32 +598,32 @@ class Amendment(models.Model):
 
     """The authorization that is being changed"""
     authorization = models.ForeignKey(Authorization, related_name='amendments', on_delete=models.PROTECT,
-                                      verbose_name=_('mandate'))
+                                      verbose_name=_l('mandate'))
 
     """Date of the change"""
-    date = models.DateField(verbose_name=_('date'))
+    date = models.DateField(verbose_name=_l('date'))
 
     """IBAN before change"""
-    previous_iban = IBANField(verbose_name=_('previous IBAN'), blank=True)
+    previous_iban = IBANField(verbose_name=_l('previous IBAN'), blank=True)
 
     """BIC before change"""
-    previous_bic = BICField(verbose_name=_('previous BIC'), blank=True)
+    previous_bic = BICField(verbose_name=_l('previous BIC'), blank=True)
 
     """This concerns a change to the bank of the person that gave the authorization."""
-    other_bank = models.BooleanField(default=False, verbose_name=_('other bank'))
+    other_bank = models.BooleanField(default=False, verbose_name=_l('other bank'))
 
     """Short description of the reason of the amendment."""
-    reason = models.CharField(max_length=250, verbose_name=_('remark'),
-                              help_text=_('Short description of the reason for the amendment'))
+    reason = models.CharField(max_length=250, verbose_name=_l('remark'),
+                              help_text=_l('Short description of the reason for the amendment'))
 
     def __str__(self):
-        return _('Amendment of %(authorization)s on %(date)s') % {'authorization': self.authorization,
+        return _l('Amendment of %(authorization)s on %(date)s') % {'authorization': self.authorization,
                                                                     'date': self.date}
 
     class Meta:
         ordering = ['date']
-        verbose_name = _('amendment')
-        verbose_name_plural = _('amendments')
+        verbose_name = _l('amendment')
+        verbose_name_plural = _l('amendments')
 
 
 class DebtCollectionAssignment(models.Model):
@@ -637,16 +637,16 @@ class DebtCollectionAssignment(models.Model):
     PREFIX = 'IA-MSG-'
 
     """Internal description of the assignment. Is not passed on to the bank or the cashed (the person paying)."""
-    description = models.CharField(max_length=50, verbose_name=_('description'))
+    description = models.CharField(max_length=50, verbose_name=_l('description'))
 
     """Date and time this assignment was created."""
-    created_on = models.DateTimeField(verbose_name=_('created on'), auto_now_add=True)
+    created_on = models.DateTimeField(verbose_name=_l('created on'), auto_now_add=True)
 
     """Start date and time of the period this assignment is related to."""
-    start = models.DateTimeField(verbose_name=_('begin'), null=True, blank=True)
+    start = models.DateTimeField(verbose_name=_l('begin'), null=True, blank=True)
 
     """End date and time of the period this assignment is related to."""
-    end = models.DateTimeField(verbose_name=_('end'), null=True, blank=True)
+    end = models.DateTimeField(verbose_name=_l('end'), null=True, blank=True)
 
     def file_identification(self):
         """Returns the file identification with prefix"""
@@ -669,8 +669,8 @@ class DebtCollectionAssignment(models.Model):
 
     class Meta:
         ordering = ['-created_on']
-        verbose_name = _('Direct withdrawal-task')
-        verbose_name_plural = _('Direct withdrawal-tasks')
+        verbose_name = _l('Direct withdrawal-task')
+        verbose_name_plural = _l('Direct withdrawal-tasks')
 
 
 class DebtCollectionBatch(models.Model):
@@ -682,33 +682,33 @@ class DebtCollectionBatch(models.Model):
 
     class StatusChoices(models.TextChoices):
         """Possible sequence types for a debt collection batch."""
-        NEW = 'N', _("New")  # New batch
-        PROCESSED = 'V', _("Processed")  # The batch is processed by the bank and the debt collection is being executed.
-        DECLINED = 'W', _("Declined")  # The batch was declined by the bank.
-        CANCELLED = 'A', _("Cancelled")  # The batch was cancelled.
+        NEW = 'N', _l("New")  # New batch
+        PROCESSED = 'V', _l("Processed")  # The batch is processed by the bank and the debt collection is being executed.
+        DECLINED = 'W', _l("Declined")  # The batch was declined by the bank.
+        CANCELLED = 'A', _l("Cancelled")  # The batch was cancelled.
 
     class SequenceTypes(models.TextChoices):
         """Possible sequence types for a debt collection batch."""
-        FRST = 'FRST', _('First collection')  # First debt collection within a series on the same authorization.
-        RCUR = 'RCUR', _('Continuation of direct withdrawal')  # Continuation debt collection within the same authorization.
-        FNAL = 'FNAL', _('Last collection')  # Final debt collection within the same authorization.
-        OOFF = 'OOFF', _('One-time direct withdrawal')  # Singular debt collection without repetition.
+        FRST = 'FRST', _l('First collection')  # First debt collection within a series on the same authorization.
+        RCUR = 'RCUR', _l('Continuation of direct withdrawal')  # Continuation debt collection within the same authorization.
+        FNAL = 'FNAL', _l('Last collection')  # Final debt collection within the same authorization.
+        OOFF = 'OOFF', _l('One-time direct withdrawal')  # Singular debt collection without repetition.
 
     """Prefix for reference number"""
     PREFIX = 'IA-PMTINF-'
 
     """Assignment that this batch is a part of."""
     assignment = models.ForeignKey(DebtCollectionAssignment, related_name='batches', on_delete=models.PROTECT,
-                                   verbose_name=_('assignment'))
+                                   verbose_name=_l('assignment'))
 
     """The date on which this debt collection batch should be executed."""
-    execution_date = models.DateField(verbose_name=_('date of execution'))
+    execution_date = models.DateField(verbose_name=_l('date of execution'))
 
     """Sequence Type for this debt collection batch."""
-    sequence_type = models.CharField(max_length=4, choices=SequenceTypes.choices, verbose_name=_('sequence type'))
+    sequence_type = models.CharField(max_length=4, choices=SequenceTypes.choices, verbose_name=_l('sequence type'))
 
     """Status of this batch."""
-    status = models.CharField(max_length=1, choices=StatusChoices.choices, verbose_name=_('status'))
+    status = models.CharField(max_length=1, choices=StatusChoices.choices, verbose_name=_l('status'))
 
     def reference_number(self):
         """Returns the reference number with prefix."""
@@ -731,8 +731,8 @@ class DebtCollectionBatch(models.Model):
 
     class Meta:
         ordering = ['assignment', 'execution_date']
-        verbose_name = _('direct withdrawal-batch')
-        verbose_name_plural = _('direct withdrawal-batches')
+        verbose_name = _l('direct withdrawal-batch')
+        verbose_name_plural = _l('direct withdrawal-batches')
 
 
 class DebtCollectionInstruction(models.Model):
@@ -750,24 +750,24 @@ class DebtCollectionInstruction(models.Model):
 
     """Batch this instruction is a part of."""
     batch = models.ForeignKey(DebtCollectionBatch, related_name='instructions', on_delete=models.PROTECT,
-                              verbose_name=_('batch'))
+                              verbose_name=_l('batch'))
 
     """Authorization that is used to collect this debt."""
     authorization = models.ForeignKey(Authorization, related_name='instructions', on_delete=models.PROTECT,
-                                      verbose_name=_('mandate'))
+                                      verbose_name=_l('mandate'))
 
     """End-to-end-id. This will be passed on to the cashed (the person paying)."""
-    end_to_end_id = models.CharField(max_length=35, verbose_name=_('end-to-end-id'), validators=[SEPA_CHAR_VALIDATOR])
+    end_to_end_id = models.CharField(max_length=35, verbose_name=_l('end-to-end-id'), validators=[SEPA_CHAR_VALIDATOR])
 
     """Description rule."""
-    description = models.CharField(max_length=140, verbose_name=_('description'), validators=[SEPA_CHAR_VALIDATOR])
+    description = models.CharField(max_length=140, verbose_name=_l('description'), validators=[SEPA_CHAR_VALIDATOR])
 
     """Amount to be collected."""
-    amount = models.DecimalField(max_digits=8, decimal_places=2, verbose_name=_('amount'))
+    amount = models.DecimalField(max_digits=8, decimal_places=2, verbose_name=_l('amount'))
 
     """An amendment given with this instruction."""
     amendment = models.OneToOneField(Amendment, related_name='instruction', on_delete=models.PROTECT,
-                                     verbose_name=_('amendment'), null=True, blank=True)
+                                     verbose_name=_l('amendment'), null=True, blank=True)
 
     objects = DebtCollectionInstructionManager()
 
@@ -784,8 +784,8 @@ class DebtCollectionInstruction(models.Model):
 
     class Meta:
         ordering = ['batch', 'authorization']
-        verbose_name = _('direct withdrawal-instruction')
-        verbose_name_plural = _('direct withdrawal-instructions')
+        verbose_name = _l('direct withdrawal-instruction')
+        verbose_name_plural = _l('direct withdrawal-instructions')
 
 
 class Reversal(models.Model):
@@ -830,27 +830,27 @@ class Reversal(models.Model):
 
     """Debt collection instruction that was reversed."""
     instruction = models.OneToOneField(DebtCollectionInstruction, related_name='reversal', on_delete=models.PROTECT,
-                                       verbose_name=_('instruction'))
+                                       verbose_name=_l('instruction'))
 
     """Date of reversal"""
-    date = models.DateField(verbose_name=_('Processing date'),
-                            help_text=_("Fill out processing date, not rent date. See Rabobank Internet Banking."))
+    date = models.DateField(verbose_name=_l('Processing date'),
+                            help_text=_l("Fill out processing date, not rent date. See Rabobank Internet Banking."))
 
     """Indicates if the reversal is a pre-settlement (REFUSAL) or post-settlement (RETURN or REFUND)."""
-    pre_settlement = models.BooleanField(default=False, verbose_name=_('pre-settlement'),
-                                         help_text=_("A debit reversal is pre-settlement when the withdrawal happens "
+    pre_settlement = models.BooleanField(default=False, verbose_name=_l('pre-settlement'),
+                                         help_text=_l("A debit reversal is pre-settlement when the withdrawal happens "
                                                      "before the crediting of the direct withdrawal has taken place."))
 
     """Reason for reversal"""
-    reason = models.CharField(max_length=4, choices=ReversalReasons.choices, verbose_name=_('reason'))
+    reason = models.CharField(max_length=4, choices=ReversalReasons.choices, verbose_name=_l('reason'))
 
     def __str__(self):
-        return _('Debit reversal %s') % self.instruction.debt_collection_reference()
+        return _l('Debit reversal %s') % self.instruction.debt_collection_reference()
 
     class Meta:
         ordering = ['date']
-        verbose_name = _('debit reversal')
-        verbose_name_plural = _('reversal')
+        verbose_name = _l('debit reversal')
+        verbose_name_plural = _l('reversal')
 
 
 class DebtCollectionTransaction(Transaction):
@@ -873,7 +873,7 @@ class ReversalTransaction(Transaction):
 
     """Reversal that this transaction is related to."""
     reversal = models.OneToOneField(Reversal, related_name='transaction', on_delete=models.PROTECT,
-                                    verbose_name=_('debit reversal'))
+                                    verbose_name=_l('debit reversal'))
 
     def get_absolute_url(self):
         return reverse('personal_tab:reversal_transaction_detail', args=[self.pk])

--- a/amelie/personal_tab/pos_models.py
+++ b/amelie/personal_tab/pos_models.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import User
 from django.db import models
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 import io
 import qrcode
@@ -16,8 +16,8 @@ import qrcode.image.svg
 
 class PendingPosToken(models.Model):
     class TokenTypes(models.TextChoices):
-        LOGIN = 'login', _("Login token")
-        REGISTRATION = 'registration', _("Registration token")
+        LOGIN = 'login', _l("Login token")
+        REGISTRATION = 'registration', _l("Registration token")
 
     token = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     user = models.ForeignKey(User, blank=True, null=True, related_name='pending_pos_login_tokens', on_delete=models.CASCADE)

--- a/amelie/personal_tab/pos_views.py
+++ b/amelie/personal_tab/pos_views.py
@@ -11,8 +11,8 @@ from django.urls import reverse, reverse_lazy
 from django.utils import timezone
 from django.views import View
 from django.views.generic import TemplateView, FormView
-from django.utils.translation import gettext_lazy as _
-from django.utils.translation import gettext
+from django.utils.translation import gettext_lazy as _l
+from django.utils.translation import gettext as _
 
 from amelie.activities.models import Activity
 from amelie.members.models import Person
@@ -30,7 +30,7 @@ def require_cookie_corner_pos(func):
     if not settings.DEBUG:
         return request_passes_test(
             lambda r: (r.META['REMOTE_ADDR'] in settings.COOKIE_CORNER_POS_IP_ALLOWLIST or r.user.is_superuser),
-            reden=_('Access for personal tab only.')
+            reden=_l('Access for personal tab only.')
         )(func)
     else:
         return func
@@ -64,13 +64,13 @@ class PosProcessRFIDView(RequireCookieCornerMixin, View):
     http_method_names = ['post']
     def post(self, request):
         if 'tags' not in request.POST:
-            messages.error(request, _("Something went wrong, please try again later."))
+            messages.error(request, _l("Something went wrong, please try again later."))
             return redirect('personal_tab:pos_logout')
 
         tags = json.loads(request.POST['tags'])
 
         if not tags:
-            messages.error(request, _('No cards were scanned, please try again.'))
+            messages.error(request, _l('No cards were scanned, please try again.'))
             return redirect('personal_tab:pos_logout')
 
         people = [r.person for r in RFIDCard.objects.filter(code__in=tags, active=True)]
@@ -85,17 +85,17 @@ class PosProcessRFIDView(RequireCookieCornerMixin, View):
                     return redirect("personal_tab:pos_shop")
                 else:
                     messages.error(request,
-                                   _('You do not have a valid mandate or are not a member anymore. Contact the board for help.'))
+                                   _l('You do not have a valid mandate or are not a member anymore. Contact the board for help.'))
                     return redirect('personal_tab:pos_logout')
             else:
-                messages.error(request, _('RFID-cards from multiple people recognised. Please scan one card at a time.'))
+                messages.error(request, _l('RFID-cards from multiple people recognised. Please scan one card at a time.'))
                 return redirect('personal_tab:pos_logout')
         else:
             if len(tags) == 1:
                 request.session['POS_REGISTER_TAG_ID'] = tags[0]
                 return redirect('personal_tab:pos_generate_qr', type="register")
             else:
-                messages.error(request, _('Multiple unknown RFID-cards detected. Please scan one card at a time.'))
+                messages.error(request, _l('Multiple unknown RFID-cards detected. Please scan one card at a time.'))
                 return redirect('personal_tab:pos_logout')
 
 
@@ -113,7 +113,7 @@ class PosGenerateQRView(RequireCookieCornerMixin, TemplateView):
             # Create new registration token
             context['token'] = PendingPosToken.objects.create(type=PendingPosToken.TokenTypes.REGISTRATION)
         else:
-            raise ValueError(_("Invalid token type requested."))
+            raise ValueError(_l("Invalid token type requested."))
         return context
 
     def get(self, request, *args, **kwargs):
@@ -121,7 +121,7 @@ class PosGenerateQRView(RequireCookieCornerMixin, TemplateView):
 
         # If type is invalid, raise an error
         if qr_type is None or qr_type not in ['login', 'register']:
-            raise ValueError(_("Invalid token type requested!"))
+            raise ValueError(_l("Invalid token type requested!"))
 
         # If someone was logged in, he's not any more!
         if 'POS_LOGIN_UID' in self.request.session:
@@ -151,23 +151,23 @@ class PosGenerateQRView(RequireCookieCornerMixin, TemplateView):
 
             # Check the RFID card that was scanned if it can be registered
             if 'POS_REGISTER_TAG_ID' not in request.session:
-                messages.error(request, _("No card was scanned, please try again."))
+                messages.error(request, _l("No card was scanned, please try again."))
                 return redirect('personal_tab:pos_logout')
 
             # Extract card ID and remove from session
             rfid_card = request.session['POS_REGISTER_TAG_ID']
             del request.session['POS_REGISTER_TAG_ID']
             if not rfid_card:
-                messages.error(request, _("Something went wrong while scanning the RFID card. Please try again."))
+                messages.error(request, _l("Something went wrong while scanning the RFID card. Please try again."))
                 return redirect('personal_tab:pos_logout')
 
             # Check if card is already registered
             try:
                 rfid_card_obj = RFIDCard.objects.get(code=rfid_card)
                 if rfid_card_obj.active:
-                    messages.error(request, _("This card is already registered."))
+                    messages.error(request, _l("This card is already registered."))
                 else:
-                    messages.error(request, _("This card has already been registered, "
+                    messages.error(request, _l("This card has already been registered, "
                                               "but has not been activated on the website. "
                                               "Please contact the board."))
                 return redirect('personal_tab:pos_logout')
@@ -187,11 +187,11 @@ class PosGenerateQRView(RequireCookieCornerMixin, TemplateView):
                 # User has just logged in, check if user has a Person object and is allowed to do stuff.
                 # If the user is allowed to do stuff, do the action that the pending token indicates (register/login).
                 if not pending_token.user.is_active:
-                    messages.error(request, _("This user is inactive. Please contact the board."))
+                    messages.error(request, _l("This user is inactive. Please contact the board."))
                     return redirect('personal_tab:pos_logout')
 
                 if not hasattr(pending_token.user, 'person'):
-                    messages.error(request, _("You are (not yet/ no longer) a member of Inter-Actief. "
+                    messages.error(request, _l("You are (not yet/ no longer) a member of Inter-Actief. "
                                               "Ask the board for a membership form."))
                     return redirect('personal_tab:pos_logout')
 
@@ -203,7 +203,7 @@ class PosGenerateQRView(RequireCookieCornerMixin, TemplateView):
                 elif pending_token.type == PendingPosToken.TokenTypes.REGISTRATION:
                     # User is OK to register card! Register card to person and return to the main screen.
                     RFIDCard(person=pending_token.user.person, code=rfid_card, active=True).save()
-                    messages.success(request, _("Card successfully registered. Please scan the card again to log in."))
+                    messages.success(request, _l("Card successfully registered. Please scan the card again to log in."))
                     return redirect('personal_tab:pos_logout')
             elif pending_token is not None:
                 # Unused token, delete it anyway, we will create a new one in the get_context_data for safety reasons.
@@ -225,7 +225,7 @@ class PosGenerateQRView(RequireCookieCornerMixin, TemplateView):
             # Save registration token and RFID card tag to session
             self.request.session['POS_REGISTRATION_TOKEN'] = str(context['token'].token)
         else:
-            raise ValueError(_("Invalid token type requested."))
+            raise ValueError(_l("Invalid token type requested."))
 
         return super(PosGenerateQRView, self).render_to_response(context, **response_kwargs)
 
@@ -236,7 +236,7 @@ class PosVerifyTokenView(TemplateView):
     def render_to_response(self, context, **response_kwargs):
         uuid = self.kwargs.get('uuid', None)
         if uuid is None:
-            context['message'] = _("Invalid login token, please try again!")
+            context['message'] = _l("Invalid login token, please try again!")
             context['success'] = False
 
         # If no user is logged in, redirect to login and then back here.
@@ -249,28 +249,28 @@ class PosVerifyTokenView(TemplateView):
         try:
             pending_login = PendingPosToken.objects.get(token=uuid)
         except PendingPosToken.DoesNotExist:
-            context['message'] = _("Invalid token, please try again!")
+            context['message'] = _l("Invalid token, please try again!")
             context['success'] = False
         except ValidationError:
-            context['message'] = _("Invalid token, please try again!")
+            context['message'] = _l("Invalid token, please try again!")
             context['success'] = False
 
         if pending_login is not None and pending_login.user is not None:
-            context['message'] = _("This token was already used before, please try again!")
+            context['message'] = _l("This token was already used before, please try again!")
             context['success'] = False
         elif pending_login is not None:
             pending_login.user = self.request.user
             pending_login.save()
             if pending_login.type == PendingPosToken.TokenTypes.LOGIN:
-                context['message'] = _("Cookie Corner login verified successfully!")
+                context['message'] = _l("Cookie Corner login verified successfully!")
             elif pending_login.type == PendingPosToken.TokenTypes.REGISTRATION:
-                context['message'] = _("New card registration verified successfully!")
+                context['message'] = _l("New card registration verified successfully!")
             else:
-                context['message'] = _("Unknown token verified successfully!")
+                context['message'] = _l("Unknown token verified successfully!")
             context['success'] = True
 
         if 'message' not in context:
-            context['message'] = _("An unknown error occurred, please try again!")
+            context['message'] = _l("An unknown error occurred, please try again!")
             context['success'] = False
 
         return super(PosVerifyTokenView, self).render_to_response(context, **response_kwargs)
@@ -282,7 +282,7 @@ class PosCheckLoginAjaxView(RequireCookieCornerMixin, View):
             pending_login = PendingPosToken.objects.get(token=uuid)
         except PendingPosToken.DoesNotExist:
             return HttpJSONResponse({
-                'message': str(gettext("The login code is invalid or expired, please try again!.")),
+                'message': str(_("The login code is invalid or expired, please try again!.")),
                 'status': False,
                 'error': True,
             })
@@ -325,9 +325,9 @@ class PosLogoutView(RequireCookieCornerMixin, View):
         msg_preset = self.request.GET.get("msg_preset", None)
         if msg_preset is not None:
             if msg_preset == "timeout":
-                messages.info(request, _("Session timed out. You were logged out."))
+                messages.info(request, _l("Session timed out. You were logged out."))
             elif msg_preset == "cancelled":
-                messages.info(request, _("Purchase cancelled. You are now logged out."))
+                messages.info(request, _l("Purchase cancelled. You are now logged out."))
 
         # Redirect to the home page
         return redirect('personal_tab:pos_index')
@@ -387,11 +387,11 @@ class PosShopView(RequireCookieCornerMixin, TemplateView):
             del request.session['POS_LOGIN_UID']
 
         if person is None:
-            messages.error(request, _("No user was logged in. No products were purchased, please try again."))
+            messages.error(request, _l("No user was logged in. No products were purchased, please try again."))
             return redirect("personal_tab:pos_logout")
 
         if 'cart' not in request.POST:
-            messages.error(request, _("Invalid shopping cart. No products are bought. Please try again. (error 1)"))
+            messages.error(request, _l("Invalid shopping cart. No products are bought. Please try again. (error 1)"))
             return redirect("personal_tab:pos_logout")
 
         cart = json.loads(request.POST['cart'])
@@ -404,22 +404,22 @@ class PosShopView(RequireCookieCornerMixin, TemplateView):
         action_processed = False
 
         if not cart:
-            messages.error(request, _("No products were selected. Please try again."))
+            messages.error(request, _l("No products were selected. Please try again."))
             return redirect("personal_tab:pos_logout")
 
         for i in cart:
             if 'product' not in i or 'amount' not in i:
-                messages.error(request, _("Invalid shopping cart. No products are bought. Please try again. (error 2)"))
+                messages.error(request, _l("Invalid shopping cart. No products are bought. Please try again. (error 2)"))
                 return redirect("personal_tab:pos_logout")
 
             try:
                 item = Article.objects.get(id=i['product'])
             except Article.DoesNotExist:
-                messages.error(request, _("Invalid shopping cart. No products are bought. Please try again. (error 3)"))
+                messages.error(request, _l("Invalid shopping cart. No products are bought. Please try again. (error 3)"))
                 return redirect("personal_tab:pos_logout")
 
             if not item.is_available:
-                messages.error(request, _("Invalid shopping cart. No products are bought. Please try again. (error 4)"))
+                messages.error(request, _l("Invalid shopping cart. No products are bought. Please try again. (error 4)"))
                 return redirect("personal_tab:pos_logout")
 
             amount = i['amount']
@@ -445,7 +445,7 @@ class PosShopView(RequireCookieCornerMixin, TemplateView):
         has_discount = reduce(lambda x, y: x or y, [bool(t['discount']) for t in transactions])
 
         return render(request, 'pos/success.html', {
-            'success_text': _('Purchase registered!'),
+            'success_text': _l('Purchase registered!'),
             'transactions': transactions,
             'discount': has_discount,
             'free_cookie_winner': free_cookie_winner,
@@ -464,7 +464,7 @@ class PosShopView(RequireCookieCornerMixin, TemplateView):
 
         if 'pos_person' not in context:
             # No person was detected, redirect to login screen
-            messages.error(self.request, _("You have been logged out. No purchase was made. Please try again"))
+            messages.error(self.request, _l("You have been logged out. No purchase was made. Please try again"))
             return redirect("personal_tab:pos_logout")
 
         # Keep the user logged in
@@ -496,19 +496,19 @@ class PosRegisterExternalCardView(RequireCookieCornerMixin, FormView):
             rfid_person = Person.objects.get(id=form.cleaned_data['person'])
         except Person.DoesNotExist:
             # ERROR: Person does not exist
-            messages.error(self.request, _("Selected user does not exist, please try again."))
+            messages.error(self.request, _l("Selected user does not exist, please try again."))
             return redirect("personal_tab:pos_logout")
 
         user = rfid_person.user
 
         if user is None or user.is_active is False:
             # ERROR: User does not exist or is inactive
-            messages.error(self.request, _("This person is (not) a member of Inter-Actief (anymore)."))
+            messages.error(self.request, _l("This person is (not) a member of Inter-Actief (anymore)."))
             return redirect("personal_tab:pos_logout")
 
         if not hasattr(user, 'person'):
             # ERROR: User is no member of IA (any more)
-            messages.error(self.request, _("This person is (not) a member of Inter-Actief (anymore)."))
+            messages.error(self.request, _l("This person is (not) a member of Inter-Actief (anymore)."))
             return redirect("personal_tab:pos_logout")
 
         # Go to the card scan step
@@ -530,11 +530,11 @@ class PosRegisterExternalCardView(RequireCookieCornerMixin, FormView):
 
         if 'pos_person' not in context:
             # No person was detected, redirect to login screen
-            messages.error(request, _("You have been logged out. No purchase was made. Please try again"))
+            messages.error(request, _l("You have been logged out. No purchase was made. Please try again"))
             return redirect("personal_tab:pos_logout")
 
         if not context['pos_person'].is_board() and not context['pos_person'].user.is_superuser:
-            messages.error(request, _('You are not a board member of Inter-Actief. '
+            messages.error(request, _l('You are not a board member of Inter-Actief. '
                                          'Ask the board to register your card.'))
             return redirect("personal_tab:pos_logout")
 
@@ -557,14 +557,14 @@ class PosScanExternalCardView(RequireCookieCornerMixin, TemplateView):
 
         if 'POS_LOGIN_UID' not in request.session:
             # No person was detected, redirect to login screen
-            messages.error(request, _("You have been logged out. No card was registered. Please try again"))
+            messages.error(request, _l("You have been logged out. No card was registered. Please try again"))
             return redirect("personal_tab:pos_logout")
 
         return self.render_to_response({})
 
     def post(self, request):
         if 'tags' not in request.POST:
-            messages.error(request, _("Something went wrong, please try again later."))
+            messages.error(request, _l("Something went wrong, please try again later."))
             return redirect('personal_tab:pos_logout')
 
         # Get person
@@ -575,28 +575,28 @@ class PosScanExternalCardView(RequireCookieCornerMixin, TemplateView):
             del self.request.session['POS_RFID_PERSON_ID']
 
         if not person:
-            messages.error(request, _('Something went wrong, please try again later.'))
+            messages.error(request, _l('Something went wrong, please try again later.'))
             return redirect('personal_tab:pos_logout')
 
         tags = json.loads(request.POST['tags'])
 
         if not tags:
-            messages.error(request, _('No cards were scanned, please try again.'))
+            messages.error(request, _l('No cards were scanned, please try again.'))
             return redirect('personal_tab:pos_logout')
 
         people = [r.person for r in RFIDCard.objects.filter(code__in=tags, active=True)]
 
         if people:
             # Card is already registered to one or more people
-            messages.error(request, _('This card is already registered.'))
+            messages.error(request, _l('This card is already registered.'))
             return redirect('personal_tab:pos_logout')
         else:
             if len(tags) == 1:
                 # User is OK to register card! Register card to person and return to the main screen.
                 RFIDCard(person=person, code=tags[0], active=True).save()
-                messages.success(request, _("Card successfully registered. You have been logged out."))
+                messages.success(request, _l("Card successfully registered. You have been logged out."))
                 return redirect('personal_tab:pos_logout')
 
             else:
-                messages.error(request, _('Multiple unknown RFID-cards detected. Please scan one card at a time. You have been logged out.'))
+                messages.error(request, _l('Multiple unknown RFID-cards detected. Please scan one card at a time. You have been logged out.'))
                 return redirect('personal_tab:pos_logout')

--- a/amelie/personal_tab/statistics.py
+++ b/amelie/personal_tab/statistics.py
@@ -1,6 +1,6 @@
 from django.db import connection
 from django.db.models import Count, Sum
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.calendar.models import Event
 from amelie.members.models import MembershipType
@@ -263,7 +263,7 @@ def statistics_alexia_transactions(start, end):
     truncate_date = connection.ops.date_trunc_sql('day', 'date')
     alexia_rows = alexia_transactions.extra({'day': truncate_date}).values('day', 'description').annotate(
         Sum('price')).order_by('day', 'description')
-    return {'header': [_('Name')], 'rows': alexia_rows, 'sum': alexia_sum}
+    return {'header': [_l('Name')], 'rows': alexia_rows, 'sum': alexia_sum}
 
 
 def statistics_alexia_transactions_total(start, end):
@@ -273,22 +273,22 @@ def statistics_alexia_transactions_total(start, end):
 def statistics_functions_ledgers():
     return [(statistics_cookie_corner_ledger_breakdown(ledger),
              'l{}'.format(ledger.pk),
-             _('{} ledger statistics').format(ledger.name.capitalize()),
+             _l('{} ledger statistics').format(ledger.name.capitalize()),
              ledger.default_statistics)
             for ledger in LedgerAccount.objects.all()]
 
 
 def get_functions():
     return [
-        (statistics_cookie_corner_breakdown, 'u', _('Personal tab statistics'), False),
-        (statistics_cookie_corner_totals, 's', _('Personal tab balance'), True),
-        (statistics_activities, 'a', _('Activities'), True),
-        (statistics_alexia_transactions, 'x', _('Alexia transactions'), False),
-        (statistics_contribution_transactions, 'c', _('Contribution transactions'), True),
-        (statistics_discount_periods, 'k', _('Discount offers'), True),
-        (statistics_discount_credits, 'g', _('Discount balances'), True),
-        (statistics_other_transactions, 'o', _('Custom transactions'), True),
-        (statistics_totals, 't', _('Totals'), True),
+        (statistics_cookie_corner_breakdown, 'u', _l('Personal tab statistics'), False),
+        (statistics_cookie_corner_totals, 's', _l('Personal tab balance'), True),
+        (statistics_activities, 'a', _l('Activities'), True),
+        (statistics_alexia_transactions, 'x', _l('Alexia transactions'), False),
+        (statistics_contribution_transactions, 'c', _l('Contribution transactions'), True),
+        (statistics_discount_periods, 'k', _l('Discount offers'), True),
+        (statistics_discount_credits, 'g', _l('Discount balances'), True),
+        (statistics_other_transactions, 'o', _l('Custom transactions'), True),
+        (statistics_totals, 't', _l('Totals'), True),
     ] + statistics_functions_ledgers()
 
 

--- a/amelie/publications/models.py
+++ b/amelie/publications/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.core.validators import FileExtensionValidator
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.publications.managers import PublicationManager
 
@@ -10,29 +10,29 @@ class PublicationType(models.Model):
         max_length=150,
         blank=False,
         null=False,
-        verbose_name=_('type name'),
+        verbose_name=_l('type name'),
         unique=True,
     )
     description = models.TextField(
         blank=True,
         null=True,
-        verbose_name=_('description'),
+        verbose_name=_l('description'),
     )
     default_thumbnail = models.ImageField(
         upload_to='data/uploads/%Y/%m/%d/',
         max_length=100,
         blank=False,
         null=False,
-        verbose_name=_('default thumbnail'),
-        help_text=_(
+        verbose_name=_l('default thumbnail'),
+        help_text=_l(
             'This thumbnail is shown when a publication of this type is uploaded without thumbnail.'
         ),
     )
 
     class Meta:
         ordering = ['type_name']
-        verbose_name = _('publication type')
-        verbose_name_plural = _('publication types')
+        verbose_name = _l('publication type')
+        verbose_name_plural = _l('publication types')
 
     def __str__(self):
         return '%s' % self.type_name
@@ -53,15 +53,15 @@ class Publication(models.Model):
         validators=[FileExtensionValidator(allowed_extensions=['pdf'])],
     )
 
-    is_featured = models.BooleanField(default=False, verbose_name=_('featured'))
-    public = models.BooleanField(default=True, verbose_name=_('public'))
+    is_featured = models.BooleanField(default=False, verbose_name=_l('featured'))
+    public = models.BooleanField(default=True, verbose_name=_l('public'))
 
     objects = PublicationManager()
 
     class Meta:
         ordering = ['-date_published']
-        verbose_name = _('publication')
-        verbose_name_plural = _('publications')
+        verbose_name = _l('publication')
+        verbose_name_plural = _l('publications')
 
     def __str__(self):
         return '%s' % self.name

--- a/amelie/room_duty/models.py
+++ b/amelie/room_duty/models.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.functional import cached_property
 from django.utils.timezone import localtime
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.members.models import Person
 
@@ -14,7 +14,7 @@ class RoomDutyPool(models.Model):
     A pool of persons that can do room duties in a room duty table,
     for example the board or board+cb.
     """
-    name = models.CharField(max_length=250, verbose_name=_("Name"))
+    name = models.CharField(max_length=250, verbose_name=_l("Name"))
     unsorted_persons = models.ManyToManyField(Person, related_name="room_duty_pools")
 
     @cached_property
@@ -26,8 +26,8 @@ class RoomDutyPool(models.Model):
         return self.name
 
     class Meta:
-        verbose_name = _("Office duty")
-        verbose_name_plural = _("Office duty pools")
+        verbose_name = _l("Office duty")
+        verbose_name_plural = _l("Office duty pools")
         ordering = ['-name']
 
 
@@ -35,9 +35,9 @@ class RoomDutyTable(models.Model):
     """
     A set of room duties to fill in availability for, usually one week.
     """
-    title = models.CharField(max_length=250, verbose_name=_("Title"))
+    title = models.CharField(max_length=250, verbose_name=_l("Title"))
     unsorted_pool = models.ManyToManyField(Person, related_name="room_duty_tables")
-    begin = models.DateTimeField(verbose_name=_("Starts"))
+    begin = models.DateTimeField(verbose_name=_l("Starts"))
     balcony_duty = models.ForeignKey("room_duty.BalconyDutyAssociation", null=True, blank=True, on_delete=models.SET_NULL)
 
     def __str__(self):
@@ -49,14 +49,14 @@ class RoomDutyTable(models.Model):
         return [r.person for r in records]
 
     class Meta:
-        verbose_name = _("Office duty schedule")
-        verbose_name_plural = _("Office duty schedules")
+        verbose_name = _l("Office duty schedule")
+        verbose_name_plural = _l("Office duty schedules")
         ordering = ['-begin']
 
 
 class BalconyDutyAssociation(models.Model):
-    association = models.CharField(max_length=255, verbose_name=_("Association"))
-    is_this_association = models.BooleanField(verbose_name=_("Is Inter-Actief"))
+    association = models.CharField(max_length=255, verbose_name=_l("Association"))
+    is_this_association = models.BooleanField(verbose_name=_l("Is Inter-Actief"))
     rank = models.PositiveIntegerField(unique=True)
 
     def __init__(self, *args, association=None, **kwargs):
@@ -101,10 +101,10 @@ class RoomDuty(models.Model):
     One room duty, usually a morning or afternoon on a working day.
     """
     table = models.ForeignKey(RoomDutyTable, related_name="room_duties", on_delete=models.CASCADE)
-    begin = models.DateTimeField(verbose_name=_('Starts'))
-    end = models.DateTimeField(verbose_name=_('Ends'))
+    begin = models.DateTimeField(verbose_name=_l('Starts'))
+    end = models.DateTimeField(verbose_name=_l('Ends'))
 
-    participant_set = models.ManyToManyField(Person, blank=True, related_name="room_duties", verbose_name=_("Boardmembers"))
+    participant_set = models.ManyToManyField(Person, blank=True, related_name="room_duties", verbose_name=_l("Boardmembers"))
 
     update_count = models.PositiveIntegerField(default=0)
 
@@ -114,7 +114,7 @@ class RoomDuty(models.Model):
         if self.begin != None and self.end != None:
             if self.begin >= self.end:
                 raise ValidationError(
-                    {"begin": [_('Start may not be after of simultaneous to end.')]})
+                    {"begin": [_l('Start may not be after of simultaneous to end.')]})
 
     # Properties for ical_event
     @property
@@ -141,7 +141,7 @@ class RoomDuty(models.Model):
         return RoomDutyAvailability(room_duty=self, person=person)
 
     def __str__(self):
-        return _("Office duty from {begin} till {end}").format(
+        return _l("Office duty from {begin} till {end}").format(
             begin=localtime(self.begin).strftime("%Y-%m-%d %H:%M:%S"),
             end=localtime(self.end).strftime("%Y-%m-%d %H:%M:%S"))
 
@@ -150,8 +150,8 @@ class RoomDuty(models.Model):
         super(RoomDuty, self).save(*args, **kwargs)
 
     class Meta:
-        verbose_name = _("Office duty")
-        verbose_name_plural = _("Office duties")
+        verbose_name = _l("Office duty")
+        verbose_name_plural = _l("Office duties")
         ordering = ['begin', 'end']
 
 
@@ -160,7 +160,7 @@ class RoomDutyTableTemplate(models.Model):
     A template for a room duty table, relative to a specified start,
     for example a regular week or an exam week.
     """
-    title = models.CharField(max_length=250, verbose_name=_("Title"))
+    title = models.CharField(max_length=250, verbose_name=_l("Title"))
 
     @staticmethod
     def instantiate(template, title, pool, start_datetime, balcony_duty):
@@ -186,8 +186,8 @@ class RoomDutyTableTemplate(models.Model):
         return self.title
 
     class Meta:
-        verbose_name = _("Office duty schedule template")
-        verbose_name_plural = _("Office duty schedule templates")
+        verbose_name = _l("Office duty schedule template")
+        verbose_name_plural = _l("Office duty schedule templates")
         ordering = ['title']
 
 
@@ -198,8 +198,8 @@ class RoomDutyTemplate(models.Model):
 
     table = models.ForeignKey(RoomDutyTableTemplate, related_name="room_duties", on_delete=models.CASCADE)
 
-    begin = models.DurationField(verbose_name=_("Starts"))
-    end = models.DurationField(verbose_name=_("Ends"))
+    begin = models.DurationField(verbose_name=_l("Starts"))
+    end = models.DurationField(verbose_name=_l("Ends"))
 
     def __str__(self):
         begin = self.begin
@@ -220,7 +220,7 @@ class RoomDutyTemplate(models.Model):
         mfrom = int(begin.total_seconds() // timedelta(minutes=1).total_seconds())
         mto = int(end.total_seconds() // timedelta(minutes=1).total_seconds())
 
-        return _("Day {dfrom}, {hfrom:02d}:{mfrom:02d} till day {dto}, {hto:02d}:{mto:02d}").format(
+        return _l("Day {dfrom}, {hfrom:02d}:{mfrom:02d} till day {dto}, {hto:02d}:{mto:02d}").format(
             dfrom=dfrom,
             dto=dto,
             hfrom=hfrom,
@@ -230,19 +230,19 @@ class RoomDutyTemplate(models.Model):
         )
 
     class Meta:
-        verbose_name = _("Office duty template")
-        verbose_name_plural = _("Office duty templates")
+        verbose_name = _l("Office duty template")
+        verbose_name_plural = _l("Office duty templates")
         ordering = ['begin', 'end']
 
 
 class RoomDutyAvailability(models.Model):
     class Availabilities(models.TextChoices):
-        DIBS = 'D', _("Dibs!")
-        GLADLY = 'G', _("Yes please!")
-        AVAILABLE = 'O', _("Available")
-        RATHER_NOT = '#', _("Rather not")
-        UNAVAILABLE = 'X', _("No, sorry")
-        UNKNOWN = '?', _("Not sure yet")
+        DIBS = 'D', _l("Dibs!")
+        GLADLY = 'G', _l("Yes please!")
+        AVAILABLE = 'O', _l("Available")
+        RATHER_NOT = '#', _l("Rather not")
+        UNAVAILABLE = 'X', _l("No, sorry")
+        UNKNOWN = '?', _l("Not sure yet")
 
     room_duty = models.ForeignKey(RoomDuty, related_name="availabilities", on_delete=models.CASCADE)
     person = models.ForeignKey(Person, on_delete=models.CASCADE)
@@ -251,7 +251,7 @@ class RoomDutyAvailability(models.Model):
     hungover = models.BooleanField(default=False)
     not_in_the_break = models.BooleanField(default=False)
 
-    comments = models.CharField(blank=True, max_length=250, verbose_name=_("Comments"))
+    comments = models.CharField(blank=True, max_length=250, verbose_name=_l("Comments"))
 
     @property
     def css_class(self):
@@ -267,6 +267,6 @@ class RoomDutyAvailability(models.Model):
         return mapping[self.availability]
 
     class Meta:
-        verbose_name = _("Office duty availability")
-        verbose_name_plural = _("Office duty availabilities")
+        verbose_name = _l("Office duty availability")
+        verbose_name_plural = _l("Office duty availabilities")
 

--- a/amelie/statistics/models.py
+++ b/amelie/statistics/models.py
@@ -1,16 +1,16 @@
 from django.db import models
-from django.utils.translation import gettext_lazy as _, gettext
+from django.utils.translation import gettext_lazy as _l, gettext as _
 
 
 class Hits(models.Model):
-    date_start = models.DateField(verbose_name=_("Starts on"))
-    date_end = models.DateField(verbose_name=_("Ends on"))
-    page = models.CharField(verbose_name=_("Page"), max_length=255)
-    user_agent = models.CharField(verbose_name=_("User-Agent"), max_length=255, blank=True)
-    hit_count = models.PositiveIntegerField(verbose_name=_("Hits"), default=0)
+    date_start = models.DateField(verbose_name=_l("Starts on"))
+    date_end = models.DateField(verbose_name=_l("Ends on"))
+    page = models.CharField(verbose_name=_l("Page"), max_length=255)
+    user_agent = models.CharField(verbose_name=_l("User-Agent"), max_length=255, blank=True)
+    hit_count = models.PositiveIntegerField(verbose_name=_l("Hits"), default=0)
 
     def __str__(self):
-        return gettext("Hits between {} and {} on page '{}' with User-Agent '{}'".format(
+        return _("Hits between {} and {} on page '{}' with User-Agent '{}'".format(
             str(self.date_start),
             str(self.date_end),
             self.page,

--- a/amelie/tools/decorators.py
+++ b/amelie/tools/decorators.py
@@ -5,7 +5,7 @@ from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from urllib.parse import quote
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.api.utils import has_valid_oauth_token
 
@@ -39,42 +39,42 @@ def request_passes_test(test, needs_login=False, needs_oauth_login=False, reden=
 
 def require_ajax(func):
     return request_passes_test(lambda r: r.headers.get('x-requested-with') == 'XMLHttpRequest',
-                               reden=_('AJAX request required'))(func)
+                               reden=_l('AJAX request required'))(func)
 
 
 def require_board(func):
     return request_passes_test(lambda r: hasattr(r, 'is_board') and r.is_board,
                                needs_login=True,
-                               reden=_('Access for board members only.'))(func)
+                               reden=_l('Access for board members only.'))(func)
 
 
 def require_education(func):
     return request_passes_test(lambda r: hasattr(r, 'is_education_committee') and r.is_education_committee,
                                needs_login=True,
-                               reden=_('Access for the Educational Committee only.'))(func)
+                               reden=_l('Access for the Educational Committee only.'))(func)
 
 
 def require_lid(func):
     return request_passes_test(lambda r: (hasattr(r, 'person') and r.person.is_member()),
                                needs_login=True,
-                               reden=_('For active members only.'))(func)
+                               reden=_l('For active members only.'))(func)
 
 
 def require_lid_or_oauth(func):
     return request_passes_test(lambda r: ((hasattr(r, 'person') and r.person.is_member()) or has_valid_oauth_token(r)),
                                needs_oauth_login=True,
-                               reden=_('For active members only.'))(func)
+                               reden=_l('For active members only.'))(func)
 
 
 def require_actief(func):
     return request_passes_test(lambda r: (hasattr(r, 'person') and r.person.is_active_member()),
                                needs_login=True,
-                               reden=_('Access for active members only.'))(func)
+                               reden=_l('Access for active members only.'))(func)
 
 
 def require_superuser(func):
     return request_passes_test(lambda r: r.user.is_superuser, needs_login=True,
-                               reden=_('Only accessible by superusers.'))(func)
+                               reden=_l('Only accessible by superusers.'))(func)
 
 
 def require_committee(abbreviation):
@@ -87,6 +87,6 @@ def require_committee(abbreviation):
                                               (r.is_board or r.person.function_set.filter(
                                                   committee__abbreviation=abbreviation, end__isnull=True))),
                                    needs_login=True,
-                                   reden=_('Access for members of the committee only.'))(func)
+                                   reden=_l('Access for members of the committee only.'))(func)
 
     return _view

--- a/amelie/tools/forms.py
+++ b/amelie/tools/forms.py
@@ -9,7 +9,7 @@ from django.forms import BoundField
 from django.template.utils import get_app_template_dirs
 from django.utils import timezone
 from django.utils.safestring import mark_safe
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.style.forms import inject_style
 from amelie.members.models import LANGUAGE_CHOICES
@@ -50,9 +50,9 @@ class PeriodForm(forms.Form):
 inject_style(PeriodForm)
 
 class PeriodKeywordForm(forms.Form):
-    keywords = forms.CharField(max_length=20, label=_('Keywords'))
-    from_date = forms.DateField(label=_('Begin date:'), initial=timezone.now().date() - timedelta(days=365))
-    to_date = forms.DateField(label=_('End date:'), initial=timezone.now().date())
+    keywords = forms.CharField(max_length=20, label=_l('Keywords'))
+    from_date = forms.DateField(label=_l('Begin date:'), initial=timezone.now().date() - timedelta(days=365))
+    to_date = forms.DateField(label=_l('End date:'), initial=timezone.now().date())
 
     def __init__(self, *args, **kwargs):
         if 'to_date_required' in kwargs:
@@ -129,12 +129,12 @@ def _mail_templates():
 
 class MailTemplateTestForm(forms.Form):
     class Formats(TextChoices):
-        HTML = 'html', _("HTML")
-        PLAIN = 'plain', _("Plain text")
+        HTML = 'html', _l("HTML")
+        PLAIN = 'plain', _l("Plain text")
 
-    template = forms.ChoiceField(label=_('Template'), choices=_mail_templates())
-    language = forms.ChoiceField(label=_('Language'), choices=LANGUAGE_CHOICES, initial='nl')
-    format = forms.ChoiceField(label=_('Template'), choices=Formats.choices)
+    template = forms.ChoiceField(label=_l('Template'), choices=_mail_templates())
+    language = forms.ChoiceField(label=_l('Language'), choices=LANGUAGE_CHOICES, initial='nl')
+    format = forms.ChoiceField(label=_l('Template'), choices=Formats.choices)
 
 
 class ExportTypeSelectForm(forms.Form):
@@ -148,14 +148,14 @@ class ExportTypeSelectForm(forms.Form):
             required=False,
             widget=forms.Select(),
             initial="",
-            label=_("Only show exports of this type")
+            label=_l("Only show exports of this type")
         )
 
 
 class ExportForm(forms.Form):
     export_type = forms.CharField(max_length=100, required=False, widget=widgets.HiddenInput())
     export_details = forms.CharField(max_length=512, required=False, widget=widgets.HiddenInput())
-    reason = forms.CharField(max_length=512, label=_('Reason for export'), widget=widgets.Textarea(attrs={'rows': 3}))
+    reason = forms.CharField(max_length=512, label=_l('Reason for export'), widget=widgets.Textarea(attrs={'rows': 3}))
 
     def __init__(self, *args, rows=None, **kwargs):
         super(ExportForm, self).__init__(*args, **kwargs)
@@ -179,7 +179,7 @@ class ExportForm(forms.Form):
         elif 'activity_export_print' in self.data:
             cleaned_data['export_type'] = 'activity_export_print'
         else:
-            raise forms.ValidationError(_("Unknown data export type."))
+            raise forms.ValidationError(_l("Unknown data export type."))
 
         return cleaned_data
 

--- a/amelie/tools/mixins.py
+++ b/amelie/tools/mixins.py
@@ -10,7 +10,7 @@ from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from urllib.parse import quote
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.members.models import Committee, DogroupGeneration
 from amelie.tools.logic import current_association_year
@@ -46,7 +46,7 @@ class PassesTestMixin(object):
 
 class RequirePersonMixin(PassesTestMixin):
     needs_login = True
-    reason = _('Access for (former) members only.')
+    reason = _l('Access for (former) members only.')
 
     def test_requirement(self, request):
         return hasattr(request, 'person') and request.person
@@ -54,7 +54,7 @@ class RequirePersonMixin(PassesTestMixin):
 
 class RequireBoardMixin(PassesTestMixin):
     needs_login = True
-    reason = _('Access for boardmembers only.')
+    reason = _l('Access for boardmembers only.')
 
     def test_requirement(self, request):
         return hasattr(request, 'is_board') and request.is_board
@@ -62,7 +62,7 @@ class RequireBoardMixin(PassesTestMixin):
 
 class RequireEducationCommitteeMixin(PassesTestMixin):
     needs_login = True
-    reason = _('Access for the Educational Committee only.')
+    reason = _l('Access for the Educational Committee only.')
 
     def test_requirement(self, request):
         return hasattr(request, 'is_education_committee') and request.is_education_committee
@@ -70,7 +70,7 @@ class RequireEducationCommitteeMixin(PassesTestMixin):
 
 class RequireMemberMixin(PassesTestMixin):
     needs_login = True
-    reason = _('For active members only.')
+    reason = _l('For active members only.')
 
     def test_requirement(self, request):
         return hasattr(request, 'person') and request.person.is_member()
@@ -78,7 +78,7 @@ class RequireMemberMixin(PassesTestMixin):
 
 class RequireActiveMemberMixin(PassesTestMixin):
     needs_login = True
-    reason = _('Access for active members only.')
+    reason = _l('Access for active members only.')
 
     def test_requirement(self, request):
         return hasattr(request, 'person') and request.person.is_active_member()
@@ -86,7 +86,7 @@ class RequireActiveMemberMixin(PassesTestMixin):
 
 class RequireSuperuserMixin(PassesTestMixin):
     needs_login = True
-    reason = _('Only accessible by superusers.')
+    reason = _l('Only accessible by superusers.')
 
     def test_requirement(self, request):
         return request.user.is_superuser
@@ -97,7 +97,7 @@ class RequireCommitteeMixin(PassesTestMixin):
     Require a committee based on an abbreviation
     """
     needs_login = True
-    reason = _('Access for members of the committee only.')
+    reason = _l('Access for members of the committee only.')
     abbreviation = None
     """ Abbreviation of the committee required for accessing this page. """
 
@@ -111,7 +111,7 @@ class RequireStrictCommitteeMixin(PassesTestMixin):
     Require a committee based on an abbreviation, board not included.
     """
     needs_login = True
-    reason = _('Access for members of the committee only.')
+    reason = _l('Access for members of the committee only.')
     abbreviation = None
     """ Abbreviation of the committee required for accessing this page. """
 
@@ -126,7 +126,7 @@ class RequireCommitteeOrChildCommitteeMixin(PassesTestMixin):
     Require a committee or child committees of that committee based on an abbreviation
     """
     needs_login = True
-    reason = _('Access for members of the committee only.')
+    reason = _l('Access for members of the committee only.')
     abbreviation = None
     """ Abbreviation of the (parent) committee required for accessing this page. """
 
@@ -154,7 +154,7 @@ class RequireDoGroupParentInCurrentYearMixin(PassesTestMixin):
     Require that the person is a do group parent in this year
     """
     needs_login = True
-    reason = _('Access for do-group parents only.')
+    reason = _l('Access for do-group parents only.')
 
     def test_requirement(self, request):
         if not hasattr(request, 'person'):
@@ -176,7 +176,7 @@ class RequireCookieCornerMixin(PassesTestMixin):
     Require that the request be made from the cookie corner computer (or by a logged-in superuser)
     """
     needs_login = False
-    reason = _("Access for the cookie-corner computer only.")
+    reason = _l("Access for the cookie-corner computer only.")
 
     def test_requirement(self, request):
         return settings.DEBUG or \

--- a/amelie/tools/models.py
+++ b/amelie/tools/models.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.models import User
 from django.db import models
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.members.models import Person
 
@@ -10,8 +10,8 @@ class Profile(models.Model):
 
     class Meta:
         ordering = ['user']
-        verbose_name = _('Profile')
-        verbose_name_plural = _('Profiles')
+        verbose_name = _l('Profile')
+        verbose_name_plural = _l('Profiles')
 
     def __str__(self):
         return str(self.user)
@@ -24,27 +24,27 @@ class DataExportInformation(models.Model):
     the filters that were used for the query. The reason is given by the exporter.
     """
 
-    export_type = models.CharField(max_length=100, verbose_name=_("Export type"),
-                                   help_text=_("The type of export that was made."))
+    export_type = models.CharField(max_length=100, verbose_name=_l("Export type"),
+                                   help_text=_l("The type of export that was made."))
 
-    details = models.CharField(max_length=512, verbose_name=_("Export details"),
-                               help_text=_("Details about the export, like applied filters, the object that was "
+    details = models.CharField(max_length=512, verbose_name=_l("Export details"),
+                               help_text=_l("Details about the export, like applied filters, the object that was "
                                            "exported, etc. Empty often means that no filters have been applied."))
 
-    reason = models.CharField(max_length=512, verbose_name=_("Reason for export"),
-                              help_text=_("The reason that the user gave for the export."))
+    reason = models.CharField(max_length=512, verbose_name=_l("Reason for export"),
+                              help_text=_l("The reason that the user gave for the export."))
 
     # Allows null values in DB to allow person deletion (null=True), but require it in forms (blank=False)
-    exporter = models.ForeignKey(to=Person, verbose_name=_("Exporter"),
-                                 help_text=_("The person that executed the export"),
+    exporter = models.ForeignKey(to=Person, verbose_name=_l("Exporter"),
+                                 help_text=_l("The person that executed the export"),
                                  on_delete=models.SET_NULL, null=True, blank=False)
 
-    exporter_text = models.CharField(max_length=255, verbose_name=_("Name of exporter"),
-                                     help_text=_("String version of the exporter, for when their "
+    exporter_text = models.CharField(max_length=255, verbose_name=_l("Name of exporter"),
+                                     help_text=_l("String version of the exporter, for when their "
                                                  "Person object is removed."))
 
-    date = models.DateTimeField(auto_now_add=True, verbose_name=_("Timestamp"),
-                                help_text=_("The date and time of the export."))
+    date = models.DateTimeField(auto_now_add=True, verbose_name=_l("Timestamp"),
+                                help_text=_l("The date and time of the export."))
 
     def save(self, *args, **kwargs):
         self.exporter_text = self.exporter.full_name()

--- a/amelie/tools/templatetags/hide_email.py
+++ b/amelie/tools/templatetags/hide_email.py
@@ -3,7 +3,7 @@ import re
 
 from django import template
 from django.utils.safestring import mark_safe
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 """
 Source: https://djangosnippets.org/snippets/1349/
@@ -55,7 +55,7 @@ def hide_email(email, name=None):
     mailto_link = '<a href="\'+\'m\'+\'a\'+\'i\'+\'l\'+\'t\'+\'o\'+\':%s">%s</a>' % (
         encode_string(email), encode_string(name))
 
-    return (u"\n<noscript>(%s)</noscript>" % (_("Javascript must be enabled to reveal email address"))) \
+    return (u"\n<noscript>(%s)</noscript>" % (_l("Javascript must be enabled to reveal email address"))) \
            + ('<script type="text/javascript">// <![CDATA[' + "\n"
               + "\tdocument.write('%s')\n"
               + "\t// ]]></script>\n") % mailto_link

--- a/amelie/tools/validators.py
+++ b/amelie/tools/validators.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ValidationError
 
 from django.utils.deconstruct import deconstructible
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 
 @deconstructible
@@ -22,7 +22,7 @@ class CheckDigitValidator(object):
             total += digit * factor
 
         if total % 11 != 0:
-            raise ValidationError(_("%d is incorrect according to the check digit.") % number)
+            raise ValidationError(_l("%d is incorrect according to the check digit.") % number)
 
     def __eq__(self, other):
         return self.length == other.length

--- a/amelie/twitter/forms.py
+++ b/amelie/twitter/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.forms import widgets
 from django.template import Template
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.style.forms import inject_style
 from amelie.twitter.models import TwitterAccount
@@ -17,7 +17,7 @@ class TweetForm(forms.Form):
         try:
             t = Template(value)
         except Exception:
-            raise forms.ValidationError(_("Invalid template"))
+            raise forms.ValidationError(_l("Invalid template"))
         return value
 
     def send_tweet(self):

--- a/amelie/twitter/views.py
+++ b/amelie/twitter/views.py
@@ -1,6 +1,6 @@
 from django.shortcuts import render
 from django.template import RequestContext, Template
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.tools.decorators import require_board
 from amelie.twitter.forms import TweetForm
@@ -22,9 +22,9 @@ def new_tweet(request):
             preview = Template(form.cleaned_data['template']).render(RequestContext(request, {}))
         elif form.is_valid():
             if form.send_tweet():
-                message = _('The tweet has been sent!')
+                message = _l('The tweet has been sent!')
             else:
-                message = _('Unfortunately, an error occurred.')
+                message = _l('Unfortunately, an error occurred.')
 
             return render(request, 'message.html', locals())
 

--- a/amelie/videos/forms.py
+++ b/amelie/videos/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.activities.forms import DateTimeSelector, SplitDateTimeField
 from amelie.tools import youtube
@@ -10,7 +10,7 @@ from .models import YouTubeVideo, StreamingIAVideo
 def validate_youtube_video_id(video_id):
     video = youtube.retrieve_video_details(video_id)
     if not video:
-        raise forms.ValidationError(_('YouTube video with ID "%(video_id)s" doesn\'t exist.'), params={
+        raise forms.ValidationError(_l('YouTube video with ID "%(video_id)s" doesn\'t exist.'), params={
             'video_id': video_id
         })
 
@@ -18,7 +18,7 @@ def validate_youtube_video_id(video_id):
 def validate_streaming_video_id(video_id):
     video = streaming_ia.retrieve_video_details(video_id)
     if not video:
-        raise forms.ValidationError(_('Streaming.IA video with ID "%(video_id)s" doesn\'t exist.'), params={
+        raise forms.ValidationError(_l('Streaming.IA video with ID "%(video_id)s" doesn\'t exist.'), params={
             'video_id': video_id
         })
 

--- a/amelie/videos/models.py
+++ b/amelie/videos/models.py
@@ -1,6 +1,6 @@
 from django.urls import reverse
 from django.db import models
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.members.models import Committee
 from amelie.videos.managers import VideoManager
@@ -15,15 +15,15 @@ class BaseVideo(models.Model):
 
     publisher = models.ForeignKey(Committee, on_delete=models.PROTECT)
 
-    is_featured = models.BooleanField(default=False, verbose_name=_('Featured'))
-    public = models.BooleanField(default=True, verbose_name=_('Public'))
+    is_featured = models.BooleanField(default=False, verbose_name=_l('Featured'))
+    public = models.BooleanField(default=True, verbose_name=_l('Public'))
 
     objects = VideoManager()
 
     class Meta:
         ordering = ['-date_published']
-        verbose_name = _('Video')
-        verbose_name_plural = _('Videos')
+        verbose_name = _l('Video')
+        verbose_name_plural = _l('Videos')
 
     def __str__(self):
         return '%s' % self.title
@@ -55,8 +55,8 @@ class BaseVideo(models.Model):
 class YouTubeVideo(BaseVideo):
     class Meta:
         ordering = ['-date_published']
-        verbose_name = _('YouTube video')
-        verbose_name_plural = _('YouTube videos')
+        verbose_name = _l('YouTube video')
+        verbose_name_plural = _l('YouTube videos')
 
     def get_absolute_url(self):
         return reverse('videos:single_yt_video', args=(), kwargs={'pk': self.video_id})
@@ -65,8 +65,8 @@ class YouTubeVideo(BaseVideo):
 class StreamingIAVideo(BaseVideo):
     class Meta:
         ordering = ['-date_published']
-        verbose_name = _('Streaming.IA video')
-        verbose_name_plural = _('Streaming.IA videos')
+        verbose_name = _l('Streaming.IA video')
+        verbose_name_plural = _l('Streaming.IA videos')
 
     def get_absolute_url(self):
         return reverse('videos:single_ia_video', args=(), kwargs={'pk': self.video_id})

--- a/amelie/videos/views.py
+++ b/amelie/videos/views.py
@@ -6,7 +6,7 @@ from django.contrib import messages
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.utils.timezone import make_aware
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 from django.views.generic import ListView, DetailView, DeleteView, UpdateView, CreateView
 from googleapiclient.errors import Error as googleapiclient_Error
 from oauth2client.client import Error as oauth2client_Error
@@ -208,7 +208,7 @@ class YoutubeVideoCreate(RequireCommitteeMixin, CreateView):
             import sentry_sdk
             sentry_sdk.capture_exception(e)
 
-            messages.error(request, _("Could not connect to Youtube! "
+            messages.error(request, _l("Could not connect to Youtube! "
                                       "Please contact the WWW committee if this problem persists."))
             return redirect("videos:list_videos")
 
@@ -268,7 +268,7 @@ class StreamingVideoCreate(RequireCommitteeMixin, CreateView):
             import sentry_sdk
             sentry_sdk.capture_exception(e)
 
-            messages.error(request, _("Could not connect to Streaming.IA! "
+            messages.error(request, _l("Could not connect to Streaming.IA! "
                                       "Please contact the WWW committee if this problem persists."))
             return redirect("videos:list_videos")
 

--- a/amelie/views.py
+++ b/amelie/views.py
@@ -12,7 +12,7 @@ from django.shortcuts import render, redirect
 from django.urls import reverse_lazy, reverse
 from django.utils import timezone
 from django.utils.http import url_has_allowed_host_and_scheme, urlencode
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 from django.views.decorators.cache import never_cache
 from django.views.decorators.debug import sensitive_post_parameters, sensitive_variables
 from oauth2_provider.views import AuthorizedTokenDeleteView
@@ -256,9 +256,9 @@ def csrf_failure(request, reason=""):
     logger.warning('CSRF-check failed. Reason: %s' % reason, extra={'request': request})
 
     if reason and settings.DEBUG:
-        reason = _('CSRF-check failed. Reason: %s' % reason)
+        reason = _l('CSRF-check failed. Reason: %s' % reason)
     else:
-        reason = _('CSRF-check failed.')
+        reason = _l('CSRF-check failed.')
 
     return render(request, "403.html", {'reason': reason}, status=403)
 

--- a/amelie/weekmail/forms.py
+++ b/amelie/weekmail/forms.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from django.forms import ModelForm, ModelMultipleChoiceField, CheckboxSelectMultiple
 from django.utils import timezone
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.calendar.models import Event
 from amelie.news.models import NewsItem
@@ -11,10 +11,10 @@ from amelie.weekmail.models import WeekMail
 
 class WeekMailForm(ModelForm):
     new_activities = ModelMultipleChoiceField(required=False, queryset=Event.objects.filter(end__gte=timezone.now()), widget=CheckboxSelectMultiple,
-                                              label=_("New events"), help_text=_("Only activities in the future are shown."))
+                                              label=_l("New events"), help_text=_l("Only activities in the future are shown."))
     news_articles = ModelMultipleChoiceField(required=False, queryset=NewsItem.objects.filter(publication_date__gte=(timezone.now() - timedelta(days=31))), widget=CheckboxSelectMultiple,
-                                             label=_("News articles"),
-                                             help_text=_("Only news articles of at most 31 days ago are shown, so it is possible that no articles are shown."))
+                                             label=_l("News articles"),
+                                             help_text=_l("Only news articles of at most 31 days ago are shown, so it is possible that no articles are shown."))
 
     class Meta:
         model = WeekMail

--- a/amelie/weekmail/models.py
+++ b/amelie/weekmail/models.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 from django.db import models
 from django.utils.translation import get_language
-from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext_lazy as _l
 
 from amelie.calendar.models import Event
 from amelie.news.models import NewsItem
@@ -52,15 +52,15 @@ class WeekMail(models.Model):
     A complete week mail can be generated from this class.
     """
     class StatusOptions(models.TextChoices):
-        UNSENT = 'N', _('Not yet sent'),  # Not yet sent
-        SENDING = 'U', _('Currently sending'),  # Outgoing
-        SENT = 'V', _('Sent'),  # Sent
-        ERROR = 'E', _('Error during sending')  # Error
+        UNSENT = 'N', _l('Not yet sent'),  # Not yet sent
+        SENDING = 'U', _l('Currently sending'),  # Outgoing
+        SENT = 'V', _l('Sent'),  # Sent
+        ERROR = 'E', _l('Error during sending')  # Error
 
     class MailTypes(models.TextChoices):
-        WEEKMAIL = 'W', _("Weekly mail")
-        MASTERMAIL = 'M', _("Mastermail")
-        EDUCATION_MAIL = 'E', _("Educational mail")
+        WEEKMAIL = 'W', _l("Weekly mail")
+        MASTERMAIL = 'M', _l("Mastermail")
+        EDUCATION_MAIL = 'E', _l("Educational mail")
 
     published = models.BooleanField(default=False)
     """
@@ -80,9 +80,9 @@ class WeekMail(models.Model):
     """
     The list of activities in this week mail
     """
-    new_activities = models.ManyToManyField(Event, verbose_name=_("new events"), related_name="new_activities", blank=True)
+    new_activities = models.ManyToManyField(Event, verbose_name=_l("new events"), related_name="new_activities", blank=True)
 
-    news_articles = models.ManyToManyField(NewsItem, verbose_name=_("news articles"), blank=True)
+    news_articles = models.ManyToManyField(NewsItem, verbose_name=_l("news articles"), blank=True)
     """
     The list of news articles in this week mail
     """
@@ -97,7 +97,7 @@ class WeekMail(models.Model):
     The writer of this week mail
     """
 
-    mailtype = models.CharField(verbose_name=_("Type of mailing"), max_length=1, choices=MailTypes.choices,
+    mailtype = models.CharField(verbose_name=_l("Type of mailing"), max_length=1, choices=MailTypes.choices,
                                 default=MailTypes.WEEKMAIL)
     """
     Type of this mailing, normal week mail or master mail


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
Make the importing of gettext and gettext_lazy more consistent. (u)gettext is now imported as _, and (u)gettext_lazy as _l.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes/References Inter-Actief/amelie#432

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
yes, imports have also been updated.

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes, ran `python manage.py makemessages -e ".mail,.html,.py,.txt" -a` to check the imports of (u)gettext(_lazy).
