### PR TITLE
Fixed kcal_equivalent crashing on some values

### DIFF
--- a/amelie/personal_tab/helpers.py
+++ b/amelie/personal_tab/helpers.py
@@ -4,83 +4,90 @@ KCAL_TABLE = {
             'nl': 'tomaat',
             'en': 'tomato',
         },
-        'multiple': {
-            'nl': 'tomaten',
-            'en': 'tomatoes'
-        }
+        'multiple': {'nl': 'tomaten', 'en': 'tomatoes'},
     },
     140: {
-        'single': {
-            'nl': 'blikje cola',
-            'en': 'can of cola'
-        },
-        'multiple': {
-            'nl': 'blikjes cola',
-            'en': 'cans of cola'
-        }
+        'single': {'nl': 'blikje cola', 'en': 'can of cola'},
+        'multiple': {'nl': 'blikjes cola', 'en': 'cans of cola'},
     },
     555: {
         'single': {
             'nl': 'chocolade reep',
             'en': 'chocolate bar',
         },
-        'multiple': {
-            'nl': 'chocolade repen',
-            'en': 'chocolate bars'
-        }
+        'multiple': {'nl': 'chocolade repen', 'en': 'chocolate bars'},
     },
     3500: {
         'single': {
             'nl': 'volledig brood',
             'en': 'entire bread',
         },
-        'multiple': {
-            'nl': 'volledige broden',
-            'en': 'loaves of bread'
-        }
+        'multiple': {'nl': 'volledige broden', 'en': 'loaves of bread'},
     },
     4000: {
-        'single': {
-            'nl': 'kg suiker',
-            'en': 'kilo of sugar'
-        },
-        'multiple': {
-            'nl': 'kg suiker',
-            'en': 'kilos of sugar'
-        }
+        'single': {'nl': 'kg suiker', 'en': 'kilo of sugar'},
+        'multiple': {'nl': 'kg suiker', 'en': 'kilos of sugar'},
     },
     6400: {
-        'single': {
-            'nl': 'liter mayonaise',
-            'en': 'litre of mayonaise'
-        },
+        'single': {'nl': 'liter mayonaise', 'en': 'litre of mayonnaise'},
         'multiple': {
             'nl': 'liters mayonaise',
-            'en': 'litres of mayonaise',
-        }
+            'en': 'litres of mayonnaise',
+        },
     },
 }
 
 
 def kcal_equivalent(kcal, language):
-    # Credits to https://www.koderdojo.com/blog/algorithm-to-make-change-in-python-dynamic-programming
+    assert kcal >= 0
+
+    # Credits to https://www.koderdojo.com/blog/algorithm-to-make-change-in-python-dynamic-programming The algorithm
+    # fits the KCAL_TABLE *exactly*, if it doesn't find an exact match, the result (in currency_composition) will be
+    # None
     minimum_number_of_currency = [0]
     currency_composition = [[]]
     kcal_amounts = KCAL_TABLE.keys()
 
-    for i in range(kcal):
-        best = 100000000
+    # The base case (0 calories) is already given, so start iterating from 1
+    # Also loop up to and including kcal, since we're dealing with quantities, not indices
+    for target_kcal in range(1, kcal + 1):
+        best_number_of_currency = 100000000
         best_currency_composition = None
 
-        for j in kcal_amounts:
-            if i - j > -1 and minimum_number_of_currency[i - j] + 1 < best:
-                best = minimum_number_of_currency[i - j] + 1
-                best_currency_composition = currency_composition[i - j] + [j]
+        for kcal_amount in kcal_amounts:
+            if (
+                target_kcal >= kcal_amount
+                and minimum_number_of_currency[target_kcal - kcal_amount] + 1
+                < best_number_of_currency
+            ):
+                best_number_of_currency = (
+                    minimum_number_of_currency[target_kcal - kcal_amount] + 1
+                )
+                best_currency_composition = currency_composition[
+                    target_kcal - kcal_amount
+                ] + [kcal_amount]
 
-        minimum_number_of_currency.append(best)
+        minimum_number_of_currency.append(best_number_of_currency)
         currency_composition.append(best_currency_composition)
 
-    best = currency_composition[-1]
+    # Find the highest item in KCAL_TABLE that could be used in the equivalent. A special case is for when kcal is less
+    # than the smallest analogy
+    highest_kcal_analogy = max(
+        (kcal_amount for kcal_amount in kcal_amounts if kcal >= kcal_amount),
+        default=None,
+    )
+
+    # The best equivalent should be as close to the actual kcal amount, so we do a reverse search/filter, effectively
+    # flooring kcal to the best solution. The solution should actually exist, so filter out all the None value.
+    # Finally, the goal of this function is to be fun to look at for users. Sometimes it's a better fit to have many
+    # tomato's than a (few) liter(s) of mayonnaise, but the mayonnaise is more fun. Therefore, the best solution
+    # should also include the highest possible equivalent that's possible for the given kcal
+    best = next(
+        composition
+        for composition in reversed(currency_composition)
+        if composition is not None
+        and (highest_kcal_analogy is None or highest_kcal_analogy in composition)
+    )
 
     grouped = {}
 
@@ -90,15 +97,7 @@ def kcal_equivalent(kcal, language):
         else:
             grouped[i] = 1
 
-    string = ''
-
-    for product, amount in grouped.items():
-        if amount > 1:
-            string += str(amount) + ' ' + KCAL_TABLE[product]['multiple'][language]
-        else:
-            string += '1 ' + KCAL_TABLE[product]['single'][language]
-        string += ' & '
-
-    string = string[:-2]
-
-    return string
+    return ' & '.join(
+        f"{amount} {KCAL_TABLE[product]['multiple' if amount > 1 else 'single'][language]}"
+        for product, amount in grouped.items()
+    )

--- a/amelie/personal_tab/test_helpers.py
+++ b/amelie/personal_tab/test_helpers.py
@@ -1,0 +1,47 @@
+from django.test import testcases
+from amelie.personal_tab.helpers import kcal_equivalent
+
+
+class KCalEquivalentTest(testcases.SimpleTestCase):
+    def test_kcal_equivalent_en(self):
+        kcal = 15
+        expected = ''
+        self.assertEqual(kcal_equivalent(kcal, 'en'), expected)
+
+        kcal = 16
+        expected = '1 tomato'
+        self.assertEqual(kcal_equivalent(kcal, 'en'), expected)
+
+        kcal = 17
+        expected = '1 tomato'
+        self.assertEqual(kcal_equivalent(kcal, 'en'), expected)
+
+        kcal = 1287
+        expected = '1 chocolate bar & 5 cans of cola & 2 tomatoes'
+        self.assertEqual(kcal_equivalent(kcal, 'en'), expected)
+
+    def test_kcal_equivalent_nl(self):
+        kcal = 15
+        expected = ''
+        self.assertEqual(kcal_equivalent(kcal, 'nl'), expected)
+
+        kcal = 16
+        expected = '1 tomaat'
+        self.assertEqual(kcal_equivalent(kcal, 'nl'), expected)
+
+        kcal = 17
+        expected = '1 tomaat'
+        self.assertEqual(kcal_equivalent(kcal, 'nl'), expected)
+
+        kcal = 1287
+        expected = '1 chocolade reep & 5 blikjes cola & 2 tomaten'
+        self.assertEqual(kcal_equivalent(kcal, 'nl'), expected)
+
+    def test_kcal_equivalent_nocrash(self):
+        # Test a random set of possible values to make sure none throw an error
+        for kcal in range(1000):
+            # noinspection PyBroadException
+            try:
+                kcal_equivalent(kcal, 'en')
+            except:
+                self.fail(f'kcal_equivalent threw an exception for kcal={kcal}')


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
`kcal_equivalent` would crash if `kcal` can't exactly be made out of items in `KCAL_TABLE`, now the function won't crash anymore. I also fixed a small spelling mistake for mayonnaise and added a handful of simple tests

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes/References Inter-Actief/amelie#830

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
yes, I have included the translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes

It's been a while since I has to write idiomatic Python code, I hope this is not too bad :sweat_smile:. A PEP8 formatter was used, though I don't think this makes things more readable...