### PR TITLE
Longer spotify caching and disabled logging for spotify rate limit exceeded

### DIFF
--- a/amelie/narrowcasting/views.py
+++ b/amelie/narrowcasting/views.py
@@ -142,6 +142,9 @@ def room_spotify_now_playing(request):
             return room_spotify_now_playing(request)
         except ValueError as e:
             data = {'error': True, 'code': 500, 'msg': str(e)}
+    elif res.status_code == 429:
+        # Since we often exceed the rate limit, do not report as error
+        data = {'error': False, 'is_playing': False}
     else:
         data = {'error': True, 'code': res.status_code, 'msg': res.content.decode()}
 
@@ -184,6 +187,9 @@ def room_spotify_pause(request):
             return room_spotify_pause(request)
         except ValueError as e:
             data = {'error': True, 'code': 500, 'msg': str(e)}
+    elif res.status_code == 429:
+        # Since we often exceed the rate limit, do not report as error
+        data = {'error': False, 'is_playing': False}
     else:
         data = {'error': True, 'code': res.status_code, 'msg': res.content.decode()}
 
@@ -226,7 +232,11 @@ def room_spotify_play(request):
             return room_spotify_play(request)
         except ValueError as e:
             data = {'error': True, 'code': 500, 'msg': str(e)}
+    elif res.status_code == 429:
+        # Since we often exceed the rate limit, do not report as error
+        data = {'error': False, 'is_playing': False}
     else:
         data = {'error': True, 'code': res.status_code, 'msg': res.content.decode()}
+
 
     return JsonResponse(data)

--- a/amelie/narrowcasting/views.py
+++ b/amelie/narrowcasting/views.py
@@ -105,7 +105,7 @@ def _spotify_refresh_token(association):
             raise e
     return association
 
-@cache_page(5)
+@cache_page(15)
 def room_spotify_now_playing(request):
     identifier = request.GET.get('id', None)
     if settings.SPOTIFY_CLIENT_SECRET == "":
@@ -148,7 +148,7 @@ def room_spotify_now_playing(request):
     return JsonResponse(data)
 
 
-@cache_page(5)
+@cache_page(15)
 def room_spotify_pause(request):
     identifier = request.GET.get('id', None)
     if settings.SPOTIFY_CLIENT_SECRET == "":
@@ -190,7 +190,7 @@ def room_spotify_pause(request):
     return JsonResponse(data)
 
 
-@cache_page(5)
+@cache_page(15)
 def room_spotify_play(request):
     identifier = request.GET.get('id', None)
     if settings.SPOTIFY_CLIENT_SECRET == "":


### PR DESCRIPTION
**Please describe what your PR is fixing**
Currently the log is spammed with spotify request errors. Also we are making 50k requests per day. To reduce the requests I've increased the spotify caching to 15 seconds. Also I have suppressed the errors.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes/References Inter-Actief/amelie#903

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
no, I am unable to test this on beta
