### PR TITLE
Fix dutch cookie corner pricing

### DIFF
--- a/amelie/personal_tab/static/js/personal_tab_pos.js
+++ b/amelie/personal_tab/static/js/personal_tab_pos.js
@@ -430,7 +430,8 @@ function setupCalculator(calculator) {
                 var inputValue = parseInt(inputfield.attr('value'), 10);
                 if(!isNaN(inputValue) && inputValue > 0){
                     // Add to cart
-                    addToCart(productId, productName, parseInt(inputfield.attr('value'), 10), parseFloat(productPrice), productImage);
+                    // We replace the potential ',' by a '.' for the parseFloat function.
+                    addToCart(productId, productName, parseInt(inputfield.attr('value'), 10), parseFloat(productPrice.replace(",", ".")), productImage);
                     // Clear the input field
                     inputfield.attr('value', '');
                     // Return to main tab
@@ -470,7 +471,7 @@ function setupShopPage(){
         resetCart();
         var article_elem = $(event.currentTarget.parentElement);
         var article_id = article_elem.data('id');
-        var article_price = parseFloat(article_elem.data('price'));
+        var article_price = parseFloat(article_elem.data('price').replace(",", ".")); // Replace the ',' by a '.' for the Dutch website.
         var article_name = article_elem.data('name');
         var article_image = article_elem.data('image');
         addToCartInstant(article_id, article_name, 1, article_price, article_image);
@@ -480,7 +481,7 @@ function setupShopPage(){
         resetCart();
         var article_elem = $(event.currentTarget.parentElement);
         var article_id = article_elem.data('id');
-        var article_price = parseFloat(article_elem.data('price'));
+        var article_price = parseFloat(article_elem.data('price').replace(",", ".")); // Replace the ',' by a '.' for the Dutch website.
         var article_name = article_elem.data('name');
         var article_image = article_elem.data('image');
         addToCartInstant(article_id, article_name, 1, article_price, article_image);
@@ -489,7 +490,7 @@ function setupShopPage(){
     $('.article-addtocart').click(function(event){
         var article_elem = $(event.currentTarget.parentElement);
         var article_id = article_elem.data('id');
-        var article_price = parseFloat(article_elem.data('price'));
+        var article_price = parseFloat(article_elem.data('price').replace(",", ".")); // Replace the ',' by a '.' for the Dutch website.
         var article_name = article_elem.data('name');
         var article_image = article_elem.data('image');
         addToCart(article_id, article_name, 1, article_price, article_image);


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
The cookie corner prices in the Dutch cookie corner were broken due to a faulty attempt at parsing Dutch prices. Dutch currencies are written as "0,00" instead of "0.00". This causes the `parseFloat` method from JavaScript to break and simply return 0. 

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes Inter-Actief#616

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
yes

**Did you properly test your PR before submitting it?**
yes
