### PR TITLE
Replace built-in ConnectionError by requests.exceptions.ConnectionError

### DIFF
--- a/amelie/narrowcasting/views.py
+++ b/amelie/narrowcasting/views.py
@@ -61,7 +61,7 @@ def room_spotify_callback(request):
             "client_id": settings.SPOTIFY_CLIENT_ID,
             "client_secret": settings.SPOTIFY_CLIENT_SECRET
         })
-    except requests.exceptions.ConnectionError as e:
+    except (requests.exceptions.ConnectionError, ConnectionError) as e:
         raise ValueError(_("ConnectionError while refreshing access token:") + f" {e}")
 
     data = res.json()
@@ -85,7 +85,7 @@ def _spotify_refresh_token(association):
             "client_id": settings.SPOTIFY_CLIENT_ID,
             "client_secret": settings.SPOTIFY_CLIENT_SECRET
         })
-    except requests.exceptions.ConnectionError as e:
+    except (requests.exceptions.ConnectionError, ConnectionError) as e:
         raise ValueError(_("ConnectionError while refreshing access token:") + f" {e}")
 
     data = res.json()
@@ -124,7 +124,7 @@ def room_spotify_now_playing(request):
                             params={"market": "from_token"},
                             headers={"Authorization": "Bearer {}".format(assoc.access_token)}
                             )
-    except requests.exceptions.ConnectionError as e:
+    except (requests.exceptions.ConnectionError, ConnectionError) as e:
         log = logging.getLogger("amelie.narrowcasting.views.room_spotify_now_playing")
         log.warning(f"ConnectionError while retrieving player info: {e}")
         # Return empty response
@@ -169,7 +169,7 @@ def room_spotify_pause(request):
         res = requests.put("https://api.spotify.com/v1/me/player/pause",
                             headers={"Authorization": "Bearer {}".format(assoc.access_token)}
                             )
-    except requests.exceptions.ConnectionError as e:
+    except (requests.exceptions.ConnectionError, ConnectionError) as e:
         log = logging.getLogger("amelie.narrowcasting.views.room_spotify_now_playing")
         log.warning(f"ConnectionError while pausing Spotify player: {e}")
         # Return empty response
@@ -214,7 +214,7 @@ def room_spotify_play(request):
         res = requests.put("https://api.spotify.com/v1/me/player/play",
                             headers={"Authorization": "Bearer {}".format(assoc.access_token)}
                             )
-    except requests.exceptions.ConnectionError as e:
+    except (requests.exceptions.ConnectionError, ConnectionError) as e:
         log = logging.getLogger("amelie.narrowcasting.views.room_spotify_now_playing")
         log.warning(f"ConnectionError while unpausing Spotify player: {e}")
         # Return empty response

--- a/amelie/narrowcasting/views.py
+++ b/amelie/narrowcasting/views.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Union
 
 import requests
 from django.conf import settings
@@ -62,7 +61,7 @@ def room_spotify_callback(request):
             "client_id": settings.SPOTIFY_CLIENT_ID,
             "client_secret": settings.SPOTIFY_CLIENT_SECRET
         })
-    except ConnectionError as e:
+    except requests.exceptions.ConnectionError as e:
         raise ValueError(_("ConnectionError while refreshing access token:") + f" {e}")
 
     data = res.json()
@@ -86,7 +85,7 @@ def _spotify_refresh_token(association):
             "client_id": settings.SPOTIFY_CLIENT_ID,
             "client_secret": settings.SPOTIFY_CLIENT_SECRET
         })
-    except ConnectionError as e:
+    except requests.exceptions.ConnectionError as e:
         raise ValueError(_("ConnectionError while refreshing access token:") + f" {e}")
 
     data = res.json()
@@ -125,7 +124,7 @@ def room_spotify_now_playing(request):
                             params={"market": "from_token"},
                             headers={"Authorization": "Bearer {}".format(assoc.access_token)}
                             )
-    except Union[requests.ConnectionError, ConnectionError] as e:
+    except requests.exceptions.ConnectionError as e:
         log = logging.getLogger("amelie.narrowcasting.views.room_spotify_now_playing")
         log.warning(f"ConnectionError while retrieving player info: {e}")
         # Return empty response
@@ -170,7 +169,7 @@ def room_spotify_pause(request):
         res = requests.put("https://api.spotify.com/v1/me/player/pause",
                             headers={"Authorization": "Bearer {}".format(assoc.access_token)}
                             )
-    except Union[requests.ConnectionError, ConnectionError] as e:
+    except requests.exceptions.ConnectionError as e:
         log = logging.getLogger("amelie.narrowcasting.views.room_spotify_now_playing")
         log.warning(f"ConnectionError while pausing Spotify player: {e}")
         # Return empty response
@@ -215,7 +214,7 @@ def room_spotify_play(request):
         res = requests.put("https://api.spotify.com/v1/me/player/play",
                             headers={"Authorization": "Bearer {}".format(assoc.access_token)}
                             )
-    except Union[requests.ConnectionError, ConnectionError] as e:
+    except requests.exceptions.ConnectionError as e:
         log = logging.getLogger("amelie.narrowcasting.views.room_spotify_now_playing")
         log.warning(f"ConnectionError while unpausing Spotify player: {e}")
         # Return empty response


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
A second attempt at fixing the connection error message for the Spotify API.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes Inter-Actief/amelie#926

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
no
