### PR TITLE
Give the KasCo access to the banners on the website and the television

### DIFF
--- a/amelie/companies/views.py
+++ b/amelie/companies/views.py
@@ -16,7 +16,7 @@ from amelie.companies.forms import CompanyForm, BannerForm, TelevisionBannerForm
 from amelie.companies.models import BaseBanner, Company, CompanyEvent, TelevisionBanner, WebsiteBanner, VivatBanner
 from amelie.members.models import Committee
 from amelie.statistics.decorators import track_hits
-from amelie.tools.decorators import require_board
+from amelie.tools.decorators import require_board, require_committee
 from amelie.tools.forms import PeriodForm
 from amelie.tools.calendar import ical_calendar
 from amelie.tools.http import HttpJSONResponse

--- a/amelie/companies/views.py
+++ b/amelie/companies/views.py
@@ -56,7 +56,7 @@ def company_details(request, slug):
     return render(request, 'companies/company_details.html', {'obj': obj, 'is_board': is_board})
 
 
-@require_board
+@require_committee("KasCo")
 def banner_list(request):
     """ List of all banners """
     website_banners = WebsiteBanner.objects.all()


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
Provide members of the KasCo access to the banners that are displayed on the website and television

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
No issue linked

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
no
