### PR TITLE
Add preference for having your birthday on the frontpage.

### DIFF
--- a/amelie/views.py
+++ b/amelie/views.py
@@ -23,7 +23,7 @@ from amelie.companies.models import CompanyEvent
 from amelie.forms import AmelieAuthenticationForm
 from amelie.news.models import NewsItem
 from amelie.members.forms import PersonalDetailsEditForm, PersonalStudyEditForm
-from amelie.members.models import Person, Committee, StudyPeriod
+from amelie.members.models import Person, Committee, StudyPeriod, Preference
 from amelie.education.models import Complaint, EducationEvent
 from amelie.statistics.decorators import track_hits
 from amelie.tools.auth import get_user_info, unlink_totp, unlink_acount, unlink_passkey, register_totp, register_passkey
@@ -254,13 +254,16 @@ def frontpage(request):
     if request.user.is_authenticated:
         # MediaCie check
         context['mediacie'] = request.person.is_in_committee('MediaCie')
-        
+
         # Room Duty check
         context['is_roomduty'] = request.person.is_room_duty()
 
         # Birthdays
-        context['birthdays'] = Person.objects.members().filter(date_of_birth__day=date.today().day,
-                                                               date_of_birth__month=date.today().month).distinct()
+        context['birthdays'] = Person.objects.members().filter(
+            date_of_birth__day=date.today().day,
+            date_of_birth__month=date.today().month,
+            preferences__name="birthday_show_frontpage",
+        ).distinct()
 
         # Complaints
         if request.is_board:


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
Members can now choose to have their birthday on the frontpage

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes/References Inter-Actief/amelie#413

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
yes, as we now have another preference to exclude birthdays from the public. Look at [this](https://github.com/Inter-Actief/amelie-private/pull/444) for more info.

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
yes, the birthday preference needs to be updated the following way: make adjustable for everyone, make default true, change to 'show my birthday on the frontpage' (it currently is the opposite.)

**Did you properly test your PR before submitting it?**
yes
