### PR TITLE
WIP: Cancel transactions upon activity movement and create new ones

### DIFF
--- a/amelie/activities/views.py
+++ b/amelie/activities/views.py
@@ -50,6 +50,7 @@ from amelie.calendar.models import Participation, Event
 from amelie.members.forms import PersonSearchForm
 from amelie.members.models import Person, Photographer
 from amelie.members.query_forms import ActivityMailingForm
+from amelie.personal_tab.models import ActivityTransaction
 from amelie.tools import amelie_messages, types
 from amelie.tools.decorators import require_actief, require_lid, require_committee, require_board
 from amelie.tools.forms import PeriodForm, ExportForm, PeriodKeywordForm
@@ -1169,6 +1170,37 @@ class ActivityCreateView(RequireActiveMemberMixin, ActivityEditMixin, CreateView
 class ActivityUpdateView(ActivitySecurityMixin, ActivityEditMixin, UpdateView):
     model = Activity
     form_class = ActivityForm
+
+    def form_valid(self, form):
+        # If the date has changed, we have to update any existing transactions to the new activity date. The existing
+        # transactions are refunded and will be re-created on the same date.
+        person = self.request.person
+        if person is None:
+            raise Exception("Updating requires a person")
+
+        old_obj = self.get_object()
+        new_obj = form.instance
+        print(f"Old date: {old_obj.begin}")
+        print(f"New date: {new_obj.begin}")
+        if old_obj != None and form.cleaned_data['begin'].date() != old_obj.begin.date():
+            # Undo and create new transactions
+            from amelie.personal_tab import transactions
+            for participation in old_obj.participation_set.all():
+
+                transactions.participation_transaction(participation, f"Moved {old_obj}", cancel=True,
+                                                       added_by=person)
+
+                # Create a new transaction
+                price, with_enrollment_options = participation.calculate_costs()
+                reason = _("Enrolled for {activity}").format(activity=new_obj.summary)
+
+                transaction = ActivityTransaction(price=price, description=reason,
+                                                  participation=participation, event=old_obj,
+                                                  person=participation.person, date=new_obj.begin,
+                                                  with_enrollment_options=with_enrollment_options, added_by=person)
+                transaction.save()
+
+        return super().form_valid(form)
 
 
 class EnrollmentoptionListView(ActivitySecurityMixin, TemplateView):

--- a/amelie/personal_tab/transactions.py
+++ b/amelie/personal_tab/transactions.py
@@ -31,10 +31,9 @@ def participation_transaction(participation, reason, cancel=False, added_by=None
     date = max(participation.event.begin, timezone.now())
 
     if cancel:
-        try:
-            old_transaction = ActivityTransaction.objects.get(participation=participation, event=participation.event,
-                                                              person=participation.person)
-        except ActivityTransaction.DoesNotExist:
+        old_transaction = ActivityTransaction.objects.filter(participation=participation, event=participation.event,
+                                                          person=participation.person).last()
+        if not old_transaction:
             # A compensation does not need to be created because there is no transaction to compensate.
             return
 


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
When an activity is moved to another day we have to cancel all enrollments and re-enroll people on the new date.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes Inter-Actief/amelie#56

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
yes, I have included the translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
not yet
