### PR TITLE
activities: Fix enrollment editing

### DIFF
--- a/amelie/settings/generic.py
+++ b/amelie/settings/generic.py
@@ -383,6 +383,10 @@ DATETIME_INPUT_FORMATS = (
     '%Y/%m/%d',
 )
 
+# Only use cookies for HTTPS
+CSRF_COOKIE_SECURE = True
+SESSION_COOKIE_SECURE = True
+
 # Rename cookies to prevent collision with other Django installations on our webserver
 CSRF_COOKIE_NAME = 'amelie_csrftoken'
 LANGUAGE_COOKIE_NAME = 'amelie_django_language'


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
When editing an enrollment, the person was unenrolled for the activity completely.
This fixes that so just the options are edited instead.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes #829 

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, todo in Weblate

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
sort of
