### PR TITLE
fix: move allowed file extensions to single source of truth

### DIFF
--- a/amelie/activities/forms.py
+++ b/amelie/activities/forms.py
@@ -256,13 +256,15 @@ class PhotoUploadForm(forms.Form):
 
 
 class PhotoFileUploadForm(forms.Form):
-    photo_files = MultipleFileField()
+    allowed_extensions = ["jpg", "jpeg", "gif"]
+    photo_files = MultipleFileField(accept=','.join(map(lambda ext: f'image/{ext}', allowed_extensions)))
 
     def clean_photo_files(self):
-        allowed_extensions = ["jpg", "jpeg", "gif"]
+        validator = FileExtensionValidator(allowed_extensions=self.allowed_extensions)
+
         for file in self.files.getlist('photo_files'):
             # FileExtensionValidator raises ValidationError if an extension is not allowed
-            FileExtensionValidator(allowed_extensions=allowed_extensions)(file)
+            validator(file)
 
 
 class EventDeskActivityMatchForm(forms.Form):

--- a/amelie/tools/forms.py
+++ b/amelie/tools/forms.py
@@ -209,8 +209,8 @@ class MultipleFileInput(forms.ClearableFileInput):
 
 class MultipleFileField(forms.FileField):
     # From https://docs.djangoproject.com/en/3.2/topics/http/file-uploads/#uploading-multiple-files
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault("widget", MultipleFileInput())
+    def __init__(self, accept='*', *args, **kwargs):
+        kwargs.setdefault("widget", MultipleFileInput(attrs={'accept': accept}))
         super().__init__(*args, **kwargs)
 
     def clean(self, data, initial=None):


### PR DESCRIPTION
**Please describe what your PR is fixing**

This PR moves the allowed file extensions associated to the photo upload form to a single variable all pieces of the handling code associated with the form reference while handling the file upload. Also: as a nice-to-have: the upload form now has a filter on the client-side as well.

Someone might say that this causes the code to be coupled where it is not strictly needed, but in my opinion this makes it more clear through the entire form handling code what file extensions are allowed.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**

Fixes Inter-Actief/amelie#1006

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**

no

**Does your PR include any django migrations?**

no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**

no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**

no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**

no

**Did you properly test your PR before submitting it?**
yes

