### PR TITLE
900 allow deletion of pictures and set pictures to private

### DIFF
--- a/amelie/activities/templates/gallery_photo.html
+++ b/amelie/activities/templates/gallery_photo.html
@@ -13,6 +13,11 @@
 			{% trans "Photos" %} {{ obj }} ({{ position }} / {{ total }})
 
 			<a class="looks-like-a-button" href="{{ obj.get_photo_url }}">{% trans 'All photos' %}</a>
+
+			{% if with_permissions %}
+			<a class="looks-like-a-button" style="background-color: rgba(255, 0, 0, 0.788);" href="{% url 'activities:gellery_photo_delete' pk photo_id  %}">{% trans 'Delete' %}</a>
+			<a class="looks-like-a-button" style="background-color: rgba(177, 174, 174, 0.788);" href="{% url 'activities:gallery_photo_toggle_visibility' pk photo_id  %}">{% trans nextVisibility %}</a>
+			{% endif %}
 		</h2>
 
     <div class="content">

--- a/amelie/activities/urls.py
+++ b/amelie/activities/urls.py
@@ -42,6 +42,8 @@ urlpatterns = [
     path('<int:pk>/mailing/', views.activity_mailing, name='mailing'),
     path('<int:pk>/photos/random/', views.activity_random_photo, name='random_photo'),
     path('<int:pk>/photo/<int:photo>/', views.gallery_photo, name='gallery_photo'),
+    path('<int:pk>/photo/<int:photo>/togglevisibility', views.toggle_visibility, name='gallery_photo_toggle_visibility'),
+    path('<int:pk>/photo/<int:photo>/delete', views.delete_photo, name='gellery_photo_delete'),
     path('<int:pk>/photos/', views.gallery, name='gallery'),
     path('<int:pk>/photos/<int:page>/', views.gallery, name='gallery'),
 

--- a/amelie/activities/views.py
+++ b/amelie/activities/views.py
@@ -914,7 +914,6 @@ class UploadPhotoFilesView(RequireCommitteeMixin, FormView):
         else:
             return self.form_invalid(form)
 
-
 class ClearPhotoUploadDirView(RequireCommitteeMixin, View):
     abbreviation = "MediaCie"
     http_method_names = ['get', 'post']
@@ -938,7 +937,10 @@ class ClearPhotoUploadDirView(RequireCommitteeMixin, View):
 
 def gallery_photo(request, pk, photo):
     activity = get_object_or_404(Activity, pk=pk)
+    photo_id = photo
     photo = get_object_or_404(activity.photos, id=photo)
+
+    print(pk, photo)
 
     if not request.user.is_authenticated and (not activity.public or not photo.public):
         raise PermissionDenied
@@ -962,8 +964,29 @@ def gallery_photo(request, pk, photo):
                 last = photos[total - 1]
 
     obj = activity
+    with_permissions = hasattr(request, "is_board") and request.is_board or hasattr(request, "person") and request.person.is_in_committee("MediaCie")
+    nextVisibility = f'Change to {"Private" if photo.public else "Public"}'
+
     return render(request, "gallery_photo.html", locals())
 
+@require_committee('MediaCie')
+def delete_photo(request, pk, photo):
+    activity = get_object_or_404(Activity, pk=pk)
+    photo = get_object_or_404(activity.photos, id=photo)
+
+    if not request.user.is_authenticated and (not activity.public or not photo.public):
+        raise PermissionDenied
+    
+    # return redirect("activities:photos", pk=pk)
+
+@require_committee('MediaCie')
+def toggle_visibility(request, pk, photo):
+    activity = get_object_or_404(Activity, pk=pk)
+    photo = get_object_or_404(activity.photos, id=photo)
+
+    if not request.user.is_authenticated and (not activity.public or not photo.public):
+        raise PermissionDenied
+    
 
 def gallery(request, pk, page=1):
     activity = get_object_or_404(Activity, pk=pk)

--- a/amelie/files/models.py
+++ b/amelie/files/models.py
@@ -222,6 +222,18 @@ class Attachment(models.Model):
     thumb_file_medium = property(get_thumb(preferred='medium'))
     thumb_file_small = property(get_thumb(preferred='small'))
 
+    def delete(self):
+        super().delete()
+        def quiet_remove(path):
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+        quiet_remove(os.path.join(settings.MEDIA_ROOT, str(self.thumb_file_large)))
+        quiet_remove(os.path.join(settings.MEDIA_ROOT, str(self.thumb_file_medium)))
+        quiet_remove(os.path.join(settings.MEDIA_ROOT, str(self.thumb_file_small)))
+        quiet_remove(self.file.path)
+
     @staticmethod
     def search_images(query, max_results=None):
         results = None


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
Creates two buttons on every image that allow for MediaCie or Board members to change image to Private or Public and Delete it

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes Inter-Actief/amelie#900

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes

<img width="732" height="175" alt="{5E186AC5-EEC7-41BA-86F0-5C7168D04A1B}" src="https://github.com/user-attachments/assets/9dfd0021-dd6e-4f50-abb2-254176e9ac63" />