### PR TITLE
fix: profile picture always exactly 150px

### DIFF
--- a/amelie/members/templates/includes/person_data_table.html
+++ b/amelie/members/templates/includes/person_data_table.html
@@ -4,7 +4,7 @@
     <table class="table">
         <tbody>
             <tr>
-                <td class="profile_picture">
+                <td>
                     {% if obj.picture %}
                         <img src="{% url 'members:person_picture' obj.id obj.slug %}" alt="{{ obj }}" class="profile_picture"/>
                     {% else %}

--- a/amelie/style/static/css/compiled.css
+++ b/amelie/style/static/css/compiled.css
@@ -11203,6 +11203,8 @@ img.profile_picture_small {
   vertical-align: top;
 }
 img.profile_picture {
+  min-width: 150px;
+  max-width: 150px;
   width: 150px;
   vertical-align: top;
 }

--- a/amelie/style/static/less/classes/query-classes.less
+++ b/amelie/style/static/less/classes/query-classes.less
@@ -9,6 +9,8 @@ img {
   }
 
   &.profile_picture {
+    min-width: 150px;
+    max-width: 150px;
     width: 150px;
     vertical-align: top;
   }


### PR DESCRIPTION
**Please describe what your PR is fixing**

This PR makes sure that the profile picture is visible for mobile on the /profile page. Apparently, adding min-width and max-width css properties forces the parent element (td) to stay the same size, no matter the viewport.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**

Fixes Inter-Actief/amelie#816

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**

no

**Does your PR include any django migrations?**

no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
yes, I've compiled my CSS

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**

Yes, by hardcoding a profile picture on the beta server. The profile picture is now always 150px
