### PR TITLE
fix: reverse wizard layout buttons, 'next'/'submit' button is default action

### DIFF
--- a/amelie/members/templates/includes/registration/wizard_buttons.html
+++ b/amelie/members/templates/includes/registration/wizard_buttons.html
@@ -1,12 +1,6 @@
 {% load i18n %}
 
 <div class="buttons">
-    {% if wizard.steps.prev %}
-        <button name="wizard_goto_step" type="submit" value="{{ wizard.steps.first }}" formnovalidate
-                onclick="return confirm('{% trans 'Any changes on this page may be lost. Are you sure you want to go back?' %}');">{% trans "Back to first step" %}</button>
-        <button name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}" formnovalidate
-                onclick="return confirm('{% trans 'Any changes on this page may be lost. Are you sure you want to go back?' %}');">{% trans "Back to previous step" %}</button>
-    {% endif %}
     {% if wizard.steps.next %}
         <input class="float-right" type="submit" value="{% trans 'Continue to next step' %}"/>
     {% else %}
@@ -15,5 +9,11 @@
         {% else %}
             <input class="float-right" type="submit" value="{% trans 'Send form and print' %}"/>
         {% endif %}
+    {% endif %}
+    {% if wizard.steps.prev %}
+        <button name="wizard_goto_step" type="submit" value="{{ wizard.steps.first }}" formnovalidate
+                onclick="return confirm('{% trans 'Any changes on this page may be lost. Are you sure you want to go back?' %}');">{% trans "Back to first step" %}</button>
+        <button name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}" formnovalidate
+                onclick="return confirm('{% trans 'Any changes on this page may be lost. Are you sure you want to go back?' %}');">{% trans "Back to previous step" %}</button>
     {% endif %}
 </div>


### PR DESCRIPTION
**Please describe what your PR is fixing**

This PR 'reverses' the order of the wizard layout buttons (see #1037), since the browser takes the first submit button/input when the user presses enter. This is apparently the only way to do this.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**

Fixes #1037

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**

no

**Does your PR include any django migrations?**

no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**

no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**

no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**

no

**Did you properly test your PR before submitting it?**

yes
