### PR TITLE
fix: add default yt thumbnail to api request snippet and handle accordingly

### DIFF
--- a/amelie/tools/youtube.py
+++ b/amelie/tools/youtube.py
@@ -8,7 +8,7 @@ def retrieve_video_details(video_id):
     service_list_response = service.videos().list(
         id=video_id,
         part='snippet',
-        fields='items(snippet(description,publishedAt,thumbnails/high,thumbnails/standard,title))',
+        fields='items(snippet(description,publishedAt,thumbnails/high,thumbnails/standard,thumbnails/default,title))',
     ).execute()
 
     if len(service_list_response['items']) == 0:


### PR DESCRIPTION
**Please describe what your PR is fixing**

This PR fixes the issue that a YouTube video does not save when a 'standard' thumbnail does not exist.
If it does not exist while creating, return 400, and if it does not exist while updating, don't change the thumbnail url column in the database.

Edit: this pr also adds the 'default' thumbnail to `snippet`.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**

Fixes #755

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**

no

**Does your PR include any django migrations?**

no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**

no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**

no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**

no

**Did you properly test your PR before submitting it?**

yes

(tested it with a separate YouTube API key I created myself)
