### PR TITLE
Return empty string for email in graphQL instead of Null

### DIFF
--- a/amelie/members/graphql.py
+++ b/amelie/members/graphql.py
@@ -110,9 +110,9 @@ class CommitteeType(DjangoObjectType):
     information = graphene.String(description=_("Committee information (localized for user)"))
 
     def resolve_email(obj: Committee, info):
-        """Resolves committee e-mail. Returns None if the e-mail is private and the user is not a board member."""
+        """Resolves committee e-mail. Returns empty string if the e-mail is private and the user is not a board member."""
         if obj.private_email and not is_board(info):
-            return None
+            return ''
         return obj.email
 
     def resolve_function_set(obj: Committee, info, include_past_members=False):


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
Returns an empty string in stead of None when querying a hidden email of a committee in graphql

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
amelie#1091

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes
