### PR TITLE
Update payment method when editing an enrollment

### DIFF
--- a/amelie/activities/templates/activity_enrollment_form.html
+++ b/amelie/activities/templates/activity_enrollment_form.html
@@ -34,7 +34,7 @@
 					{% endif %}
 				</p>
 
-				{% if activity_full and not person in obj.confirmed_participants %}
+				{% if activity_full and not person in activity.confirmed_participants %}
 					<p class="icon attention">
 						{% trans 'Unfortunately, there are no more openings. You will be enrolled on the waiting list.' %}
 					</p>

--- a/amelie/activities/templates/activity_enrollment_mandate.html
+++ b/amelie/activities/templates/activity_enrollment_mandate.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block titel %}
-	{% blocktrans with name=obj.summary %}
+	{% blocktrans with name=activity.summary %}
 		Enroll for {{ name }}
 	{% endblocktrans %}
 {% endblock titel %}
@@ -10,7 +10,7 @@
 {% block content %}
 	<div class="col-xs-12"><div class="current">
 		<h2>
-			{% blocktrans with name=obj.summary %}
+			{% blocktrans with name=activity.summary %}
 				Enroll for {{ name }}
 			{% endblocktrans %}
 		</h2>

--- a/amelie/activities/views.py
+++ b/amelie/activities/views.py
@@ -468,6 +468,18 @@ def activity_editenrollment(request, participation, obj, edited_by=None):
             answer.save()
             form.save_m2m()
 
+    # Update the payment method depending on the new price
+    new_price, _ = participation.calculate_costs()
+    if new_price == 0:
+        # If the enrollment is now free, no payment needs to be made
+        participation.payment_method = Participation.PaymentMethodChoices.NONE
+    elif participation.payment_method == Participation.PaymentMethodChoices.NONE:
+        # If it was free but now costs money, and the person has a mandate, upgrade to Mandate.
+        if participation.person.has_mandate_activities():
+            participation.payment_method = Participation.PaymentMethodChoices.AUTHORIZATION
+
+    participation.save()
+
     if not participation.waiting_list and participation.payment_method == Participation.PaymentMethodChoices.AUTHORIZATION:
         # If this is a regular Participation (not waiting list and via mandate), we need to re-add
         # the transaction to update the costs on the personal tab
@@ -484,6 +496,12 @@ def activity_editenrollment_self(request, pk):
     # Lock the Activity object for updating, prevent concurrent (un)enrollments
     obj = get_object_or_404(Activity.objects.select_for_update(), pk=pk)
     activity = obj
+
+    # do not allow editing an enrollment for an activity that may cost money if the user does not have a mandate.
+    # If this was allowed, users without a mandate would be able to sign up to activities that are free,
+    # but have some options that are not free. Currently, this is not supported.
+    if not request.person.has_mandate_activities() and obj.has_costs():
+        return render(request, "activity_enrollment_mandate.html", locals())
 
     # No exception can occur here, this has been checked before
     participation = Participation.objects.select_for_update().get(person=request.person, event=obj)

--- a/amelie/activities/views.py
+++ b/amelie/activities/views.py
@@ -494,28 +494,27 @@ def activity_editenrollment_self(request, pk):
     """
 
     # Lock the Activity object for updating, prevent concurrent (un)enrollments
-    obj = get_object_or_404(Activity.objects.select_for_update(), pk=pk)
-    activity = obj
+    activity = get_object_or_404(Activity.objects.select_for_update(), pk=pk)
 
-    # do not allow editing an enrollment for an activity that may cost money if the user does not have a mandate.
+    # Do not allow editing an enrollment for an activity that may cost money if the user does not have a mandate.
     # If this was allowed, users without a mandate would be able to sign up to activities that are free,
     # but have some options that are not free. Currently, this is not supported.
-    if not request.person.has_mandate_activities() and obj.has_costs():
+    if not request.person.has_mandate_activities() and activity.has_costs():
         return render(request, "activity_enrollment_mandate.html", locals())
 
     # No exception can occur here, this has been checked before
-    participation = Participation.objects.select_for_update().get(person=request.person, event=obj)
+    participation = Participation.objects.select_for_update().get(person=request.person, event=activity)
 
-    if not check_unenrollment_allowed(request, obj, ignore_can_unenroll=participation.waiting_list):
+    if not check_unenrollment_allowed(request, activity, ignore_can_unenroll=participation.waiting_list):
         # If something went wrong, it will be stated in the django errors
-        return redirect(obj)
+        return redirect(activity)
 
     if request.method == 'POST':
-        activity_editenrollment(request, participation, obj, edited_by=None)
+        activity_editenrollment(request, participation, activity, edited_by=None)
         # Redirect back to the activity
-        return redirect(obj)
+        return redirect(activity)
     else:
-        enrollmentoptions_forms = _build_enrollmentoptionsanswers_forms(obj,
+        enrollmentoptions_forms = _build_enrollmentoptionsanswers_forms(activity,
                                                                         request.POST if request.POST else None,
                                                                         request.user)
         update = True
@@ -529,22 +528,21 @@ def activity_editenrollment_other(request, pk, person_id):
     Edit enrollment of the person that is logged in for this activity.
     """
     # Lock the Activity object for updating, prevent concurrent (un)enrollments
-    obj = get_object_or_404(Activity.objects.select_for_update(), pk=pk)
+    activity = get_object_or_404(Activity.objects.select_for_update(), pk=pk)
     person = get_object_or_404(Person, pk=person_id)
-    activity = obj
 
 
     try:
-        participation = Participation.objects.select_for_update().get(person=person, event=obj)
+        participation = Participation.objects.select_for_update().get(person=person, event=activity)
     except Participation.DoesNotExist:
         raise Http404
 
     if request.method == 'POST':
-        activity_editenrollment(request, participation, obj, edited_by=request.person)
+        activity_editenrollment(request, participation, activity, edited_by=request.person)
         # Redirect back to the activity
-        return redirect(obj)
+        return redirect(activity)
     else:
-        enrollmentoptions_forms = _build_enrollmentoptionsanswers_forms(obj,
+        enrollmentoptions_forms = _build_enrollmentoptionsanswers_forms(activity,
                                                                         request.POST if request.POST else None,
                                                                         person.user)
         update = True
@@ -930,6 +928,7 @@ class UploadPhotoFilesView(RequireCommitteeMixin, FormView):
         else:
             return self.form_invalid(form)
 
+
 class ClearPhotoUploadDirView(RequireCommitteeMixin, View):
     abbreviation = "MediaCie"
     http_method_names = ['get', 'post']
@@ -949,6 +948,7 @@ class ClearPhotoUploadDirView(RequireCommitteeMixin, View):
                 if os.path.isfile(os.path.join(upload_dir, file)):
                     os.remove(os.path.join(upload_dir, file))
         return redirect("activities:photo_upload")
+
 
 def gallery_photo(request, pk, photo):
     activity = get_object_or_404(Activity, pk=pk)
@@ -982,6 +982,7 @@ def gallery_photo(request, pk, photo):
 
     return render(request, "gallery_photo.html", locals())
 
+
 @require_committee('MediaCie')
 def delete_photo(request, pk, photo):
     activity = get_object_or_404(Activity, pk=pk)
@@ -993,6 +994,7 @@ def delete_photo(request, pk, photo):
     photo.delete()
 
     return redirect(activity)
+
 
 @require_committee('MediaCie')
 def toggle_visibility(request, pk, photo):
@@ -1007,6 +1009,7 @@ def toggle_visibility(request, pk, photo):
     photo.save(create_thumbnails=False)
 
     return redirect("activities:gallery_photo", pk=pk, photo=photo_id)
+
 
 def gallery(request, pk, page=1):
     activity = get_object_or_404(Activity, pk=pk)

--- a/amelie/activities/views.py
+++ b/amelie/activities/views.py
@@ -477,6 +477,9 @@ def activity_editenrollment(request, participation, obj, edited_by=None):
         # If it was free but now costs money, and the person has a mandate, upgrade to Mandate.
         if participation.person.has_mandate_activities():
             participation.payment_method = Participation.PaymentMethodChoices.AUTHORIZATION
+        # Otherwise, change to cash
+        else:
+            participation.payment_method = Participation.PaymentMethodChoices.CASH
 
     participation.save()
 


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
When someone enrolls on a free activity, the NONE payment method is selected. When they then change their enrollment options so that the activity costs money, they are still not charged because of that NONE payment type. This PR fixes that issue, by updating the payment type whenever the price of an activity changes to/from €0

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
#1170 

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations, there are no textual changes made

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes, though I was unable to test behaviour with users without a mandate.
