### PR TITLE
Select previous food enrollment when editing enrollment

### DIFF
--- a/amelie/activities/templates/forms/enrollmentoption_foodquestion_answer.html
+++ b/amelie/activities/templates/forms/enrollmentoption_foodquestion_answer.html
@@ -25,7 +25,11 @@
             <option value="" data-price_extra="0" selected="selected">---------</option>
         {% endif %}
         {% for c in form.fields.dishprice.queryset.all %}
-            <option value="{{ c.id }}" data-price_extra="{{ c.price }}">{{ c.answer|capfirst }} {{ c }}</option>
+            <option value="{{ c.id }}" data-price_extra="{{ c.price }}"
+                    {% if form.dishprice.value|stringformat:"s" == c.pk|stringformat:"s" %}
+                    selected
+                    {% endif %}
+            >{{ c.answer|capfirst }} {{ c }}</option>
         {% endfor %}
         </select>
 	</span>

--- a/amelie/activities/templates/forms/enrollmentoption_foodquestion_answer.html
+++ b/amelie/activities/templates/forms/enrollmentoption_foodquestion_answer.html
@@ -22,11 +22,11 @@
 	<span>
         <select id="{{ form.dishprice.id_for_label }}" name="{{ form.dishprice.html_name}}">
         {% if not form.enrollmentoption.required %}
-            <option value="" data-price_extra="0" selected="selected">---------</option>
+            <option value="" data-price_extra="0"{% if form.dishprice.value is None %} selected{% endif %}>---------</option>
         {% endif %}
         {% for c in form.fields.dishprice.queryset.all %}
             <option value="{{ c.id }}" data-price_extra="{{ c.price }}"
-                    {% if form.dishprice.value|stringformat:"s" == c.pk|stringformat:"s" %}
+                    {% if form.dishprice.value is not None and form.dishprice.value|stringformat:"s" == c.pk|stringformat:"s" %}
                     selected
                     {% endif %}
             >{{ c.answer|capfirst }} {{ c }}</option>


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
When editing an enrollment with a food option, the previously selected option is wiped. If not careful, this may leave some people without food! This PR fixes that issue, by setting the initial value of the food dropdown to the option previously selected.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes #1073

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations, there are no textual changes

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes, tried it on my beta instance, seems to work with all options whether it is required or not.
