### PR TITLE
Add some global statistics per year for the board/almanac

### DIFF
--- a/amelie/personal_tab/templates/wrapped.html
+++ b/amelie/personal_tab/templates/wrapped.html
@@ -1,31 +1,40 @@
 {% extends "basis.html" %}
 {% load i18n %}
 
-{% block titel %}{% trans 'Cookie Corner Wrapped' %}{% endblock titel %}
+{% block titel %}{% trans 'Cookie Corner Wrapped' %}{% if global %}{% trans ' - Global statistics' %}{% endif %}{% endblock titel %}
 
 {% block content %}
   <div class="col-xs-12"><div class="ia">
     <h2>
-      {% trans 'Cookie Corner Wrapped ' %} {{ year }}
+      {% trans 'Cookie Corner Wrapped ' %} {{ year }}{% if global %}{% trans ' - Global statistics' %}{% endif %}
     </h2>
 
     <div class="content">
       <p>
         {% blocktrans with year=year%}
-          Now that the year is over, we can take a look into the usage of the cookie corner in <b>{{ year }}</b>. On this page you can view your personal statistics for the cookie corner.
+          Now that the year is over, we can take a look into the usage of the cookie corner in <b>{{ year }}</b>.
         {% endblocktrans %}
+        {% if global %}
+            {% trans 'On this page you can view the global cookie corner statistics for the entire association.' %}
+        {% else %}
+            {% trans 'On this page you can view your personal statistics for the cookie corner.' %}
+        {% endif %}
       </p>
       {% if transaction_years %}
       <p>
-          {% trans 'Or, look back on a different year:' %}&nbsp;
-          {% for tyear in transaction_years %}
-              {% if forloop.counter0 != 0 %}<span> - </span>{% endif %}
-              {% if year == tyear %}
-                  <b>{{ tyear }}</b>
+        {% trans 'Or, look back on a different year:' %}&nbsp;
+        {% for tyear in transaction_years %}
+          {% if forloop.counter0 != 0 %}<span> - </span>{% endif %}
+            {% if year == tyear %}
+              <b>{{ tyear }}</b>
+            {% else %}
+              {% if global %}
+                <a href="{% url 'personal_tab:cookie_corner_wrapped_global_year' year=tyear %}">{{ tyear }}</a>
               {% else %}
-                  <a href="{% url 'personal_tab:cookie_corner_wrapped_year' year=tyear %}">{{ tyear }}</a>
+                <a href="{% url 'personal_tab:cookie_corner_wrapped_year' year=tyear %}">{{ tyear }}</a>
               {% endif %}
-          {% endfor %}
+            {% endif %}
+        {% endfor %}
       </p>
       {% endif %}
     </div>
@@ -60,12 +69,20 @@
 
     <div class="ia">
       <h2>
-        {% trans 'Top 5 products' %}
+        {% if global %}
+          {% trans 'Top 5 products' %}
+        {% else %}
+          {% trans 'Top 10 products' %}
+        {% endif %}
       </h2>
 
       <div class="content">
         <p>
-          {% trans 'You bought certain items more than others during this year. What did you buy the most?' %}
+          {% if global %}
+            {% trans 'Certain items were bought more than others during this year. What was bought the most?' %}
+          {% else %}
+            {% trans 'You bought certain items more than others during this year. What did you buy the most?' %}
+          {% endif %}
         </p>
 
         <div class="table-responsive">
@@ -100,7 +117,7 @@
 
       <div class="content">
         <p>
-          {% trans 'Total spend in the cookie corner: ' %}
+          {% trans 'Total spent in the cookie corner: ' %}
           €{{ total.price }}
         </p>
 
@@ -109,10 +126,12 @@
           {{ total.kcal }}
         </p>
 
-        <p>
-          {% trans 'That is the caloric equivalent to:' %}
-          {{ total.equivalent }}
-        </p>
+        {% if not global %}
+          <p>
+            {% trans 'That is the caloric equivalent to:' %}
+            {{ total.equivalent }}
+          </p>
+        {% endif %}
       </div>
     </div>
   </div>
@@ -123,42 +142,64 @@
         {% trans 'Day with most transactions' %}
       </h2>
       <div class="content">
-        <p>
-          {% blocktrans with day=most_transactions.day.day|date:'d-m-Y' c=most_transactions.day.c %}
-            On {{ day }} you got a cookie {{ c }} times!
-          {% endblocktrans %}
-        </p>
-
-        <p>
-          {% trans 'You bought:' %}
-        </p>
-
-        <div class="table-responsive">
-          <table class="table">
-            <thead>
-              <tr>
-                <th>{% trans 'Item' %}</th>
-                <th>{% trans 'Price' %}</th>
-                <th>{% trans 'Kcal' %}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for transaction in most_transactions.list %}
+        {% if global %}
+          <p>
+            {% blocktrans with day=most_transactions.day.day|date:'d-m-Y' c=most_transactions.day.c %}
+              On {{ day }}, something was bought {{ c }} times!
+            {% endblocktrans %}
+          </p>
+          <div class="table-responsive">
+            <table class="table">
+              <thead>
                 <tr>
-                  <td>{{ transaction.article.name }}</td>
-                  <td>{{ transaction.article.price }}</td>
-                  <td>{{ transaction.article.kcal }}</td>
+                  <th>{% trans 'Total Price' %}</th>
+                  <th>{% trans 'Kcal' %}</th>
                 </tr>
-              {% endfor %}
+              </thead>
+              <tbody>
+                <tr>
+                  <td>{{ most_transactions.total_price }}</td>
+                  <td>{{ most_transactions.total_kcal }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        {% else %}
+          <p>
+            {% blocktrans with day=most_transactions.day.day|date:'d-m-Y' c=most_transactions.day.c %}
+              On {{ day }} you got a cookie {{ c }} times!
+            {% endblocktrans %}
+          </p>
+          <p>
+            {% trans 'You bought:' %}
+          </p>
+          <div class="table-responsive">
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>{% trans 'Item' %}</th>
+                  <th>{% trans 'Price' %}</th>
+                  <th>{% trans 'Kcal' %}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for transaction in most_transactions.list %}
+                  <tr>
+                    <td>{{ transaction.article.name }}</td>
+                    <td>{{ transaction.article.price }}</td>
+                    <td>{{ transaction.article.kcal }}</td>
+                  </tr>
+                {% endfor %}
 
-              <tr>
-                <td><b>{% trans 'Total' %}</b></td>
-                <td>{{ most_transactions.total_price }}</td>
-                <td>{{ most_transactions.total_kcal }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+                <tr>
+                  <td><b>{% trans 'Total' %}</b></td>
+                  <td>{{ most_transactions.total_price }}</td>
+                  <td>{{ most_transactions.total_kcal }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        {% endif %}
       </div>
     </div>
 
@@ -171,6 +212,9 @@
         <p>
           {% trans 'Now, lets take a look into the drinking rooms' %}
         </p>
+        {% if global %}
+          <p>{% trans 'These are the 10 most profitable drinks, and the full totals spent in the entire year.' %}</p>
+        {% endif %}
 
         {% if drink_spend_most %}
           <div class="table-responsive">
@@ -191,7 +235,7 @@
                     </tr>
                   {% endfor %}
                   <tr>
-                    <td><b>{% trans 'Total' %}</b></td>
+                    <td><b>{% trans 'Total entire year' %}</b></td>
                     <td></td>
                     <td>{{ drinks_total }}</td>
                   </tr>

--- a/amelie/personal_tab/templates/wrapped.html
+++ b/amelie/personal_tab/templates/wrapped.html
@@ -70,9 +70,9 @@
     <div class="ia">
       <h2>
         {% if global %}
-          {% trans 'Top 5 products' %}
-        {% else %}
           {% trans 'Top 10 products' %}
+        {% else %}
+          {% trans 'Top 5 products' %}
         {% endif %}
       </h2>
 
@@ -213,7 +213,7 @@
           {% trans 'Now, lets take a look into the drinking rooms' %}
         </p>
         {% if global %}
-          <p>{% trans 'These are the 10 most profitable drinks, and the full totals spent in the entire year.' %}</p>
+          <p>{% trans 'These are the 10 drinks with the most revenue, and the full total spent at drinks in the entire year.' %}</p>
         {% endif %}
 
         {% if drink_spend_most %}

--- a/amelie/personal_tab/urls.py
+++ b/amelie/personal_tab/urls.py
@@ -32,6 +32,8 @@ urlpatterns = [
 
     path('wrapped', views.cookie_corner_wrapped_main, name='cookie_corner_wrapped'),
     path('wrapped/<int:year>/', views.cookie_corner_wrapped_main, name='cookie_corner_wrapped_year'),
+    path('wrapped_global', views.cookie_corner_wrapped_global, name='cookie_corner_wrapped_global'),
+    path('wrapped_global/<int:year>/', views.cookie_corner_wrapped_global, name='cookie_corner_wrapped_global_year'),
 
     path('transactions/reversal/<int:pk>/', ReversalTransactionDetail.as_view(), name='reversal_transaction_detail'),
     path('transactions/<int:pk>/', TransactionDetail.as_view(), name='transaction_detail'),

--- a/amelie/personal_tab/views.py
+++ b/amelie/personal_tab/views.py
@@ -1840,3 +1840,121 @@ def cookie_corner_wrapped_main(request, year=None):
         'drink_spend_most': drink_spend_most,
         'drinks_total': drinks_total
     })
+
+
+@require_board
+def cookie_corner_wrapped_global(request, year=None):
+    # Only allow specifying a year if the year is in the past
+    current_year = datetime.date.today().year
+    if year is not None and year < current_year:
+        COOKIE_CORNER_WRAPPED_YEAR = year
+    elif year is not None:
+        # Redirect to the non-year view
+        return redirect("personal_tab:cookie_corner_wrapped")
+    else:
+        COOKIE_CORNER_WRAPPED_YEAR = django.conf.settings.COOKIE_CORNER_WRAPPED_YEAR
+
+    language = get_language()
+
+    transaction_years = sorted(list(set(
+        CookieCornerTransaction.objects.all().values_list('date__year', flat=True).distinct()
+    )))
+    # Remove current year if present
+    if current_year in transaction_years:
+        transaction_years.remove(current_year)
+
+    transactions = CookieCornerTransaction.objects.filter(
+        date__year=COOKIE_CORNER_WRAPPED_YEAR
+    ).all()
+
+    if len(transactions) == 0:
+        # No transactions found, display the no transactions page
+        return render(request, 'wrapped_no_transactions.html', {
+            'year': COOKIE_CORNER_WRAPPED_YEAR,
+            'transaction_years': transaction_years,
+        })
+
+    transaction_count = transactions \
+        .annotate(day=TruncDay('date')) \
+        .values('day') \
+        .annotate(c=Count('id')) \
+        .values('day', 'c')
+
+    first_transaction_of_the_year = transactions.earliest('date')
+    last_transaction_of_the_year = transactions[0]
+
+    most_transactions_day = transaction_count.order_by('c').last()
+    most_transactions_date = most_transactions_day['day']
+    most_transactions_list = transactions.filter(
+        date__month=most_transactions_date.month,
+        date__day=most_transactions_date.day
+    ).all()
+
+    total_price = 0
+    total_kcal = 0
+
+    for transaction in most_transactions_list:
+        total_price += transaction.article.price
+        total_kcal += transaction.article.kcal if transaction.article.kcal is not None else 0
+
+    """
+        Products
+    """
+    products_grouped_by_count = {}
+
+    total = {
+        'kcal': 0,
+        'price': 0
+    }
+
+    for transaction in transactions:
+        article = transaction.article
+        amount = transaction.amount
+
+        kcal = transaction.kcal()
+
+        total['kcal'] += kcal if kcal is not None else 0
+        total['price'] += transaction.price
+
+        if article in products_grouped_by_count:
+            products_grouped_by_count[article] += amount
+        else:
+            products_grouped_by_count[article] = amount
+
+    products_grouped_by_count = sorted(products_grouped_by_count.items(), key=lambda x:x[1])
+
+    products_grouped_by_count.reverse()
+
+    top_5_products = products_grouped_by_count[:10]  # Global stats have 10 products
+
+    """
+        Alexia
+    """
+
+    alexia_transactions = AlexiaTransaction.objects.filter(
+        date__year=COOKIE_CORNER_WRAPPED_YEAR
+    )
+
+    drink_spend_most = alexia_transactions \
+        .values('description', 'date__day', 'date__month') \
+        .annotate(total_price=Sum('price')) \
+        .order_by('-total_price', '-date__day', '-date__month')
+
+    drinks_total = sum(d['total_price'] for d in drink_spend_most)
+
+    return render(request, 'wrapped.html', {
+        'global': True,
+        'year': COOKIE_CORNER_WRAPPED_YEAR,
+        'transaction_years': transaction_years,
+        'first_transaction_of_the_year': first_transaction_of_the_year,
+        'last_transaction_of_the_year': last_transaction_of_the_year,
+        'most_transactions': {
+            'day': most_transactions_day,
+            'total_price': total_price,
+            'total_kcal': total_kcal,
+        },
+        'top_5_products': top_5_products,
+        'total': total,
+        'drink_spend_most': drink_spend_most[:10],
+        'drinks_total': drinks_total
+    })

--- a/amelie/statistics/templates/statistics_year.html
+++ b/amelie/statistics/templates/statistics_year.html
@@ -2,18 +2,19 @@
 {% load i18n %}
 
 {% block titel %}
-    {% trans 'Statistics' %}
+    {% blocktrans with year=year year1=year1 %}Statistics in {{ year }}/{{ year1 }}{% endblocktrans %}
 {% endblock titel %}
 
 {% block content %}
     <div class="col-xs-12"><div class="ia">
-        <h2>{% trans 'Statistics' %}</h2>
+        <h2>{% blocktrans with year=year year1=year1 %}Statistics in {{ year }}/{{ year1 }}{% endblocktrans %}</h2>
 
         <div class="content">
             <p>
-                {% blocktrans %}
-                    Below you can find statistics and information about Inter-<i>Actief</i> and the website itself.
-                    The data is no older than an hour. Data about a specific year is calculated in academic years.
+                {% blocktrans with year=year year1=year1 %}
+                    Below you can find statistics and information about Inter-<i>Actief</i> and the website itself
+                    from the academic year {{ year }}/{{ year1 }}.
+                    The data is no older than an hour. Data is calculated in academic years.
                 {% endblocktrans %}
             </p>
 
@@ -27,9 +28,8 @@
                     <li>
                         {% trans 'Statistics for specific year:' %}
                         <select id="yearselector" onchange="gotoyear()">
-                            <option value="" selected>------</option>
-                            {% for year in year_range %}
-                                <option value="{{ year }}">{{ year }}</option>
+                            {% for y in year_range %}
+                                <option value="{{ y }}"{% if year == y %} selected{% endif %}>{{ y }}</option>
                             {% empty %}
                                 <option disabled>{% trans 'No years available' %}</option>
                             {% endfor %}
@@ -55,10 +55,9 @@
           <ul>
               <li>{% trans 'Members:' %} {{ member_count }}</li>
               <li>{% trans 'Active members:' %} {{ active_member_count }}</li>
-              <li>{% trans 'Committee' %} {{ committee_count }}</li>
-              <li>{% trans 'Committee categories' %} {{ committee_category_count }}</li>
+              <li>{% trans 'Committees:' %} {{ committee_count }}</li>
               <li>{% trans 'Activities (this year):' %} {{ current_activity_count }}</li>
-              <li>{% trans 'Activities (total)' %} {{ activity_count }}</li>
+              <li>{% trans 'Board members in this year:' %} {{ board_members_in_year|length }} ({% for board in board_members_in_year %}{{ board }}{% if not forloop.last %}, {% endif %}{% empty %}<i>{% trans 'None' %}</i>{% endfor %})</li>
           </ul>
         </div>
     </div></div>
@@ -83,7 +82,6 @@
               <li>{% trans 'Transactions:' %} {{ transactions_count }}</li>
               <li>{% trans 'Transactions from personal tab:' %} {{ snacks_count }}</li>
               <li>{% trans 'Average number of daily transactions on personal tab:' %} {{ snacks_average_count }}</li>
-              <li>{% trans 'Number of transactions on personal tab today:' %} {{ snacks_today_count }}</li>
               <li>{% trans 'Registered RFID-cards:' %} {{ rfids_count }}</li>
               <li>{% trans 'Popular snacks:' %} {{ popular_snacks|join:", " }}</li>
               <li>{% trans 'Most healthy board member:' %} {{ healthiest_board_member }}</li>

--- a/amelie/statistics/urls.py
+++ b/amelie/statistics/urls.py
@@ -6,5 +6,6 @@ app_name = 'statistics'
 
 urlpatterns = [
     path('', views.statistics, name='statistics'),
+    path('<int:year>/', views.statistics_year, name='statistics_year'),
     path('hits/', views.hits, name='hits'),
 ]

--- a/amelie/statistics/views.py
+++ b/amelie/statistics/views.py
@@ -1,7 +1,7 @@
 from datetime import datetime, date, time, timedelta
 
 from django.core.cache import cache
-from django.db.models import Count, Sum
+from django.db.models import Count, Sum, Q
 from django.shortcuts import render
 from django.utils import timezone
 
@@ -10,8 +10,8 @@ from amelie.files.models import Attachment
 from amelie.members.models import Person, Committee, CommitteeCategory
 from amelie.statistics.models import Hits
 from amelie.personal_tab.models import CookieCornerTransaction, RFIDCard, Article, Transaction
-from amelie.tools.decorators import require_lid
-from amelie.tools.logic import current_academic_year_strict
+from amelie.tools.decorators import require_lid, require_board
+from amelie.tools.logic import current_academic_year_strict, association_year
 
 
 @require_lid
@@ -67,12 +67,100 @@ def statistics(request):
         stats = calculate()
         cache.set('statistics', stats, 3600)
 
-    context = {}
-    context.update(stats)
-    context["request"] = request
+    if Transaction.objects.exists():
+        stats['year_range'] = range(Transaction.objects.all().order_by('date').first().added_on.year, Transaction.objects.all().order_by('date').last().added_on.year + 1)
+    else:
+        stats['year_range'] = range(timezone.now().date().year, timezone.now().date().year + 1)
 
     # Done!
     return render(request, "statistics.html", stats)
+
+
+@require_board
+def statistics_year(request, year: int):
+    def calculate(year_dt):
+        # General statistics
+        member_count = Person.objects.members_at(year_dt.date()).count()
+        active_member_count = Person.objects.active_members_at(year_dt.date()).count()
+        committee_count = Committee.objects.active_at(year_dt.date()).count()
+
+        begin_study_year = datetime(year=current_academic_year_strict(dt=year_dt), month=9, day=1)\
+            .replace(tzinfo=timezone.get_default_timezone())
+        end_study_year = datetime(year=current_academic_year_strict(dt=year_dt)+1, month=8, day=31)\
+            .replace(tzinfo=timezone.get_default_timezone())
+
+        current_activity_count = Activity.objects.filter(begin__gt=begin_study_year, begin__lt=end_study_year)\
+                                                      .count()
+
+        # Photos
+        albums_count = Activity.objects.distinct().filter(begin__gt=begin_study_year, begin__lt=end_study_year,
+                                                          photos__gt=0).count()
+        photos_count = Attachment.objects.filter(created__gt=begin_study_year, created__lt=end_study_year,
+                                                 thumb_medium__isnull=False).count()
+        photographer_count = Attachment.objects.filter(created__gt=begin_study_year, created__lt=end_study_year,
+                                                       thumb_medium__isnull=False).values('owner').distinct().count()
+
+        # Personal Tab
+        transactions_count = Transaction.objects.filter(added_on__gt=begin_study_year, added_on__lt=end_study_year).count()
+        snacks_count = CookieCornerTransaction.objects.filter(added_on__gt=begin_study_year, added_on__lt=end_study_year).count()
+        rfids_count = RFIDCard.objects.filter(created__gt=begin_study_year, created__lt=end_study_year).count()
+
+        cc_transactions = CookieCornerTransaction.objects.filter(added_on__gt=begin_study_year, added_on__lt=end_study_year).order_by('date')
+        last_transaction = cc_transactions.last()
+        first_transaction = cc_transactions.first()
+        if first_transaction and last_transaction:
+            days = (last_transaction.date - first_transaction.date).days
+            if days < 0:  # Protect against division by 0 and negative division
+                days = 1
+        else:
+            days = 1  # Protect against division by 0
+
+        snacks_average_count = int(snacks_count / days)
+
+        transactions = CookieCornerTransaction.objects.filter(added_on__gt=begin_study_year, added_on__lt=end_study_year)\
+                .values('article').annotate(count=Count('article')).order_by('-count')[:5]
+
+        popular_snacks = ["%s (%dx)" % (Article.objects.get(pk=x['article']), x['count']) for x in transactions]
+
+
+        # Get the board members in this specific year, looking at the months November-May to avoid GMM/switchover strangeness
+        begin_association_year = datetime(year=association_year(dt=year_dt), month=11, day=1)\
+            .replace(tzinfo=timezone.get_default_timezone())
+        end_association_year = datetime(year=association_year(dt=year_dt)+1, month=5, day=30)\
+            .replace(tzinfo=timezone.get_default_timezone())
+        board_members_in_year = Person.objects.active_members_at(year_dt).filter(
+            Q(function__committee__abbreviation="Bestuur"),
+            Q(function__begin__lt=begin_association_year),
+            Q(function__end__isnull=True) | Q(function__end__gt=end_association_year)
+        ).distinct()
+
+        board_transactions = CookieCornerTransaction.objects.filter(added_on__gt=begin_study_year, added_on__lt=end_study_year)\
+            .filter(person__in=board_members_in_year).values('person')\
+            .annotate(count=Count('person')).order_by('-count')[:1]
+        healthiest_board_member = str(Person.objects.get(pk=board_transactions[0]['person'])) if len(board_transactions) > 0 else None
+
+        # Done!
+        return locals()
+
+    # From cache, or calculate anew.
+    stats = cache.get(f'statistics_{year}')
+
+    if not stats:
+        # Get statistics at the last month of the academic year, on 1 June
+        year_datetime = datetime(year=year, month=6, day=1)
+        stats = calculate(year_dt=year_datetime)
+        cache.set(f'statistics_{year}', stats, 3600)
+
+    # Add year to context for template
+    stats['year'] = year
+    stats['year1'] = year + 1
+    if Transaction.objects.exists():
+        stats['year_range'] = range(Transaction.objects.all().order_by('date').first().added_on.year, Transaction.objects.all().order_by('date').last().added_on.year + 1)
+    else:
+        stats['year_range'] = range(timezone.now().date().year, timezone.now().date().year + 1)
+
+    # Done!
+    return render(request, "statistics_year.html", stats)
 
 
 def hits(request):

--- a/amelie/tools/logic.py
+++ b/amelie/tools/logic.py
@@ -4,22 +4,28 @@ from amelie.tools.cache import get_request_cache
 
 
 # Handy functions
-def current_academic_year_strict():
+def current_academic_year_strict(dt=None):
     """
-    Calculate the current academic year, beginning on 1 september.
+    Calculate the current academic year, beginning on 1 September.
+
+    If a datetime object is given, the association year belonging to that date is calculated.
     """
-    today = timezone.now()
-    if today.month >= 9:
-        return today.year
+    if dt is None:
+        dt = timezone.now()
+
+    if dt.month >= 9:
+        return dt.year
     else:
-        return today.year - 1
+        return dt.year - 1
 
 
-def current_academic_year_with_holidays():
+def current_academic_year_with_holidays(dt=None):
     """
     Calculate the current academic year, taking into account the holidays.
 
     This counts the summer holidays as a part of the new academic year.
+
+    If a datetime object is given, the association year belonging to that date is calculated.
     """
 
     cache = get_request_cache()
@@ -30,13 +36,14 @@ def current_academic_year_with_holidays():
     if result is None:
         from amelie.education.models import Period
 
-        today = timezone.now()
+        if dt is None:
+            dt = timezone.now()
 
-        if today.month >= 9 or Period.objects.filter(year=today.year - 1, start__lte=today, end__gte=today) \
+        if dt.month >= 9 or Period.objects.filter(year=dt.year - 1, start__lte=dt, end__gte=dt) \
                 .count() == 0:  # Summer holidays
-            result = today.year
+            result = dt.year
         else:
-            result = today.year - 1
+            result = dt.year - 1
 
         cache.set('current_academic_year_with_holidays', result)
 
@@ -46,7 +53,7 @@ def current_academic_year_with_holidays():
 
 def association_year(dt=None):
     """
-    Calculate the association year starting on 1 july.
+    Calculate the association year starting on 1 July.
 
     If a datetime object is given, the association year belonging to that date is calculated.
     """


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
Add global versions per year of the main /statistics/ page and the cookie corner wrapped page.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
None, requested via mail

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no, all data is aggregated, like the existing statistics.

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
later via weblate

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes
