### PR TITLE
Fixed the right column of the mandate form disappearing for roomduty members

### DIFF
--- a/amelie/members/templates/person_mandate.html
+++ b/amelie/members/templates/person_mandate.html
@@ -22,7 +22,7 @@
                     <th>{% trans 'Signed' %}</th>
                     <th>{% trans 'Starts on' %}</th>
                     <th>{% trans 'Ends on' %}</th>
-                    {% if request.is_board or is_roomduty %}<th></th>{% endif %}
+                    {% if request.is_board or request.person.is_room_duty %}<th></th>{% endif %}
                 </tr>
             </thead>
             <tbody>
@@ -57,7 +57,7 @@
                         <td>
                             {{ mandate.end_date|default_if_none:"&mdash;" }}
                         </td>
-                        {%  if request.is_board or is_roomduty %}
+                        {%  if request.is_board or request.person.is_room_duty %}
                         <td>
                             {% if not mandate.is_signed and not mandate.end_date %}
                                 <a href="{% url 'members:mandate_form' mandate.id %}" class="icon icon-printer">{% trans 'Print' %}</a><br />


### PR DESCRIPTION
**Please describe what your PR is fixing**
Fixes the right column of the mandate form disappearing for roomduty members.

**Concretely, which issues does your PR solve?**
Fixes Inter-Actief/amelie#910

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
Not needed.

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes


To replicate the issue, you must disable your own super-user and board status on the website, since it is specifically an issue with room-duty members that are not on the board.
