### PR TITLE
Add mandate and member check for Personal tab QR code log in

### DIFF
--- a/amelie/personal_tab/pos_views.py
+++ b/amelie/personal_tab/pos_views.py
@@ -216,10 +216,16 @@ class PosGenerateQRView(RequireCookieCornerMixin, CookieCornerBetaModeMixin, Tem
                     return redirect('personal_tab:pos_logout')
 
                 if pending_token.type == PendingPosToken.TokenTypes.LOGIN:
-                    # User is OK to buy stuff! Set person ID to session, delete token and continue to the shop.
-                    self.request.session['POS_LOGIN_UID'] = pending_token.user.person.id
-                    pending_token.delete()
-                    return redirect('personal_tab:pos_shop')
+                    person = Person.objects.get(pk=pending_token.user.person.id)
+                    if person.has_mandate_consumptions() and person.is_member():
+                        # User is OK to buy stuff! Set person ID to session, delete token and continue to the shop.
+                        self.request.session['POS_LOGIN_UID'] = pending_token.user.person.id
+                        pending_token.delete()
+                        return redirect("personal_tab:pos_shop")
+                    else:
+                        messages.error(request,
+                                    _l('You do not have a valid mandate or are not a member anymore. Contact the board for help.'))
+                        return redirect('personal_tab:pos_logout')
                 elif pending_token.type == PendingPosToken.TokenTypes.REGISTRATION:
                     # User is OK to register card! Register card to person and return to the main screen.
                     RFIDCard(person=pending_token.user.person, code=rfid_card, active=True).save()


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
Adding a consumption mandate and member check when logging in on the Personal tab POS via QR code

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes Inter-Actief/amelie#1209

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes
