### PR TITLE
Allow users to set a custom sudo password

### DIFF
--- a/amelie/claudia/account_views.py
+++ b/amelie/claudia/account_views.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+from typing import Optional
 
 from django.conf import settings
 from django.contrib import messages
@@ -18,8 +19,9 @@ from django.views.generic.edit import FormView
 from sshpubkeys import SSHKey, InvalidKeyError
 
 from amelie.claudia.forms import AccountPasswordForm, AccountConfigureForwardingForm, AccountPasswordResetForm, \
-    AccountPasswordResetLinkForm, AccountActivateForm, MailAliasForm
+    AccountPasswordResetLinkForm, AccountActivateForm, MailAliasForm, KanidmSudoResetForm
 from amelie.claudia.google import GoogleSuiteAPI
+from amelie.claudia.kanidm import KanidmPerson
 from amelie.claudia.models import Mapping, Membership, AliasGroup
 from amelie.claudia.tasks import verify_object
 from amelie.members.models import Person
@@ -614,10 +616,19 @@ class KanidmActions(RequireActiveMemberMixin, View):
         return self.do_redirect()
 
 
-class KanidmSudoReset(TemplateView):
+class KanidmSudoReset(FormView):
+    form_class = KanidmSudoResetForm
     template_name = "accounts/sudo_reset.html"
 
-    def get_context_data(self, **kwargs):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        from amelie.claudia.kanidm import KanidmAPI
+        self.kanidm_api = KanidmAPI()
+        self.person: Optional[Person] = None
+        self.mp: Optional[Mapping] = None
+        self.kanidm_person: Optional[KanidmPerson] = None
+
+    def check_args(self):
         # Check reset code kwarg
         reset_code = self.kwargs.get("reset_code")
         if reset_code is None:
@@ -625,35 +636,58 @@ class KanidmSudoReset(TemplateView):
 
         # Check if a person exists with this code
         try:
-            person = Person.objects.get(sudo_reset_code=reset_code)
+            self.person = Person.objects.get(sudo_reset_code=reset_code)
         except Person.DoesNotExist:
             raise Http404(_l("This reset link is not valid."))
 
         # Check if code is not expired
-        if timezone.now() > person.sudo_reset_expiry:
-            person.sudo_reset_code = None
-            person.sudo_reset_expiry = None
-            person.save()
+        if timezone.now() > self.person.sudo_reset_expiry:
+            self.person.sudo_reset_code = None
+            self.person.sudo_reset_expiry = None
+            self.person.save()
             raise Http404(_l("This reset link is not valid."))
 
         # Get Claudia mapping
         from amelie.claudia.models import Mapping
-        mp = Mapping.find(person)
-        if not mp or not mp.get_kanidm_id():
+        self.mp = Mapping.find(self.person)
+        if not self.mp or not self.mp.get_kanidm_id():
             raise Http404(_l("This reset link is not valid."))
 
         # Get Kanidm account
-        from amelie.claudia.kanidm import KanidmAPI
-        kanidm_api = KanidmAPI()
-        kanidm_person = kanidm_api.get_person(mp.get_kanidm_id())
-        if not kanidm_person:
+        kanidm_id = self.mp.get_kanidm_id()
+        if not kanidm_id:
+            raise Http404(_l("This reset link is not valid."))
+        self.kanidm_person = self.kanidm_api.get_person(kanidm_id)
+        if not self.kanidm_person:
             raise Http404(_l("This reset link is not valid."))
 
-        # Remove reset code
-        person.sudo_reset_code = None
-        person.sudo_reset_code = None
-        person.save()
-
+    def get_context_data(self, **kwargs):
+        # Check if the request is valid
+        self.check_args()
         context = super().get_context_data(**kwargs)
-        context['new_password'] = kanidm_person.reset_posix_password()
         return context
+
+    def form_valid(self, form):
+        # Check if the request is valid
+        self.check_args()
+
+        if self.person is None or self.kanidm_person is None:
+            raise Http404(_l("This reset link is not valid."))
+
+        context = super().get_context_data()
+
+        # Remove reset code
+        self.person.sudo_reset_code = None
+        self.person.sudo_reset_code = None
+        self.person.save()
+
+        if form.cleaned_data.get("set_random", False):
+            password = None
+            context['new_password_is_random'] = True
+        else:
+            password = form.cleaned_data.get("new_password")
+            context['new_password_is_random'] = False
+
+        context['new_password'] = self.kanidm_person.reset_posix_password(new_password=password)
+        context['new_password_set'] = True
+        return self.render_to_response(context)

--- a/amelie/claudia/forms.py
+++ b/amelie/claudia/forms.py
@@ -140,3 +140,25 @@ class PersonalAliasCreateForm(forms.Form):
         if ExtraPersonalAlias.objects.filter(email=self.cleaned_data['email']).count() > 0:
             raise ValidationError(_l("This mailaddress is not unique! You might want to make a group."))
         return self.cleaned_data['email']
+
+
+class KanidmSudoResetForm(forms.Form):
+    set_random = forms.BooleanField(
+        label=_l('Generate a random password?'), required=False,
+        help_text=_l("The values from the password fields will not be used, and a random, 32-character password will be generated for you.")
+    )
+    new_password = forms.CharField(widget=widgets.PasswordInput, min_length=15, label=_l('New password'), required=False)
+    new_password2 = forms.CharField(widget=widgets.PasswordInput, min_length=15, label=_l('Repeat new password'), required=False)
+
+    def clean(self):
+        cleaned_data = super(KanidmSudoResetForm, self).clean()
+        if not cleaned_data.get("set_random"):
+            new_pw = cleaned_data.get("new_password")
+            new_pw2 = cleaned_data.get("new_password2")
+
+            if not new_pw:
+                self.add_error("new_password", _l("This field is required."))
+            if not new_pw2:
+                self.add_error("new_password2", _l("This field is required."))
+            if new_pw and new_pw2 and new_pw != new_pw2:
+                self.add_error("new_password2", _l("The new passwords do not match"))

--- a/amelie/claudia/kanidm.py
+++ b/amelie/claudia/kanidm.py
@@ -332,12 +332,17 @@ class KanidmPerson(KanidmObject):
             logger.error(e)
             return False
 
-    def reset_posix_password(self) -> Optional[str]:
-        from amelie.claudia.tools import create_password
-        new_password = create_password(length=32)
+    def reset_posix_password(self, new_password: Optional[str] = None) -> Optional[str]:
+        random_password = False
+        if new_password is None:
+            random_password = True
+            from amelie.claudia.tools import create_password
+            new_password = create_password(length=32)
+        if len(new_password) < 15:
+            raise ValueError("New password must be at least 15 characters long.")
         try:
             self.kanidm.set_person_posix_password(self.uuid, password=new_password)
-            return new_password
+            return new_password if random_password else None
         except RequestException as e:
             logger.error(e)
             return None

--- a/amelie/claudia/templates/accounts/sudo_reset.html
+++ b/amelie/claudia/templates/accounts/sudo_reset.html
@@ -7,15 +7,42 @@
     <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12"><div class="ia">
         <h2>{% trans 'Sudo password reset' %}</h2>
         <div class="content">
-            <p>
-                {% trans 'Your sudo password was reset successfully.' %}
-            </p>
-            <p>
-                {% trans 'You can find your new password below. It will only be shown this once, please save it to your password manager.' %}
-            </p>
-            <p>
-                <b>{% trans 'New password:' %}</b>&nbsp;{{ new_password }}
-            </p>
+            {% if new_password_set %}
+                <p>
+                    {% trans 'Your sudo password was reset successfully.' %}
+                </p>
+                {% if new_password_is_random %}
+                    <p>
+                        {% trans 'You can find your random new password below. It will only be shown this once, please save it to your password manager.' %}
+                    </p>
+                    <p>
+                        <b>{% trans 'New password:' %}</b>&nbsp;{{ new_password }}
+                    </p>
+                {% else %}
+                    <p>
+                        {% trans 'You may close this page.' %}
+                    </p>
+                {% endif %}
+            {% else %}
+                <p>{% trans 'Please enter a wanted sudo password in the form below. Note, this only resets your sudo password, not your login password.' %}</p>
+                <p>{% trans 'Your new password must differ from your current one and consist of at least 15 characters.' %}</p>
+                <p>{% trans 'You may also choose to use a random password, which will be displayed once after clicking the relevant button.' %}</p>
+                {% if error %}
+                    <ul class="errorlist">
+                        <li>{{ error }}</li>
+                    </ul>
+                {% endif %}
+                <form method="post" action="">
+                    {% csrf_token %}
+                    {{ form.non_field_errors }}
+                    <div class="table-responsive">
+                        <table class="table">
+                            {{ form.as_table }}
+                        </table>
+                    </div>
+                    <p><input type="submit" value="{% trans 'Reset password' %}" /></p>
+                </form>
+            {% endif %}
         </div>
     </div></div>
 {% endblock content %}


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
Allows users to set a custom sudo password, as well as generate a random one.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes #1222 

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
Later via weblate.

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes
