### PR TITLE
Enrollments column in statistics displays Event participants

### DIFF
--- a/amelie/personal_tab/statistics.py
+++ b/amelie/personal_tab/statistics.py
@@ -153,12 +153,12 @@ def statistics_activities(start, end):
             event = None
 
         event_transaction_count = activity_transactions.filter(event=event).count()
-        event_active_transaction_count = activity_transactions.filter(event=event, participation__isnull=False).count()
+        event_participants = event.participants.count() if event else activity_transactions.filter(event=event, participation__isnull=False).count()
         event_transaction_sum = activity_transactions.filter(event=event).aggregate(Sum('price'))['price__sum']
         rows.append({
             'event': event,
             'count': event_transaction_count,
-            'active_count': event_active_transaction_count,
+            'active_count': event_participants,
             'sum': event_transaction_sum
         })
     return {'rows': rows, 'sum': total, 'count': number_of_transactions, 'active_count': number_of_enrollments}


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
The Enrollments column in statistics displays the actual number of Event participants instead of the number of ActivityTransactions which have a participation linked.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes #1221 

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes
