### PR TITLE
Transaction overview form without loading all transactions

### DIFF
--- a/amelie/personal_tab/templates/cookie_corner_transactions_form.html
+++ b/amelie/personal_tab/templates/cookie_corner_transactions_form.html
@@ -1,0 +1,26 @@
+{% extends "basis.html" %}
+{% load i18n %}
+
+{% block titel %}{% trans 'Transactions' %}{% endblock titel %}
+
+{% block content %}
+    <div class="col-xs-12"><div class="ia">
+        <h2>
+            {% trans 'Transactions' %}
+
+            {% if person %}
+                {% trans 'from' %} {{ person }}
+            {% endif %}
+        </h2>
+
+        <div class="content">
+            <form class="big" method="post">
+                {% csrf_token %}
+                {{ form }}
+
+                <input type="submit" value="{% trans 'Show overview' %}" />
+            </form>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/amelie/personal_tab/urls.py
+++ b/amelie/personal_tab/urls.py
@@ -19,8 +19,10 @@ urlpatterns = [
     # Short URL to a person's own dashboard
     path('me/', views.my_dashboard, name='my_dashboard'),
 
-    path('transactions/', views.transaction_overview, name='transactions'),
+    path('transactions/', views.transaction_form, name='transactions_form'),
+    path('transactions/', views.transaction_overview, name='transactions'), # Needed because of the transaction_link template tag
     path('transactions/<int:date_from>/<int:date_to>/', views.transaction_overview, name='transactions'),
+
     path('transactions/activity/<int:pk>/', ActivityTransactionDetail.as_view(), name='activity_transaction_detail'),
     path('transactions/alexia/<int:pk>/', AlexiaTransactionDetail.as_view(), name='alexia_transaction_detail'),
     path('transactions/cookie_corner/<int:pk>/', CookieCornerTransactionDetail.as_view(),

--- a/amelie/personal_tab/urls.py
+++ b/amelie/personal_tab/urls.py
@@ -19,8 +19,7 @@ urlpatterns = [
     # Short URL to a person's own dashboard
     path('me/', views.my_dashboard, name='my_dashboard'),
 
-    path('transactions/', views.transaction_form, name='transactions_form'),
-    path('transactions/', views.transaction_overview, name='transactions'), # Needed because of the transaction_link template tag
+    path('transactions/', views.transaction_form, name='transactions'),
     path('transactions/<int:date_from>/<int:date_to>/', views.transaction_overview, name='transactions'),
 
     path('transactions/activity/<int:pk>/', ActivityTransactionDetail.as_view(), name='activity_transaction_detail'),

--- a/amelie/personal_tab/views.py
+++ b/amelie/personal_tab/views.py
@@ -459,20 +459,36 @@ def rfid_remove(request, rfid_id):
 
 
 @require_board
-def transaction_overview(request, date_from=False, date_to=False):
-    """Give an overview of transactions."""
+def transaction_form(request):
+    view_name = request.resolver_match.view_name
 
-    # Redirect to a page based on POST (handy for linking)
     if request.method == 'POST':
         form = PeriodTimeForm(request.POST)
         if form.is_valid():
             start = form.cleaned_data['datetime_from'].astimezone(tz.utc)
             end = form.cleaned_data['datetime_to'].astimezone(tz.utc)
             return HttpResponseRedirect(reverse('personal_tab:transactions', args=[_urlize(start), _urlize(end)]))
+        
+        else:
+            return render(request, 'cookie_corner_transactions_form.html', {
+                'form': form,
+                'view_name': view_name,
+            })
+    else:
+        end_date = timezone.now()
+        begin_date = end_date - timezone.timedelta(days=7)
+        return render(request, 'cookie_corner_transactions_form.html', {
+            'form': PeriodTimeForm(initial={
+                'datetime_from': begin_date,
+                'datetime_to': end_date})
+            ,
+            'view_name': view_name,
+        })
 
-    if not date_from:
-        # No period given
-        return generate_overview_new(request, None)
+
+@require_board
+def transaction_overview(request, date_from, date_to):
+    """Give an overview of transactions."""
 
     # Construct data
     try:
@@ -480,6 +496,7 @@ def transaction_overview(request, date_from=False, date_to=False):
         end = _parsedatetime(date_to)
     except ValueError:
         raise Http404(_('Invalid date`'))
+    
     return generate_overview_new(request, None, start, end)
 
 


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
When loading /personal_tab/transactions, it first loads a small form where a date can be entered, instead of loading this form and all of the transactions which have ever taken place.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes #1252

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
 no, my PR does not include translations

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
 no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes
