### PR TITLE
Checkmark for payment not needed when terminating membership

### DIFF
--- a/amelie/members/ajax_views.py
+++ b/amelie/members/ajax_views.py
@@ -12,7 +12,7 @@ from django.template.defaultfilters import slugify
 from amelie.members.forms import CommitteeForm, FunctionForm, MembershipEndForm, MembershipForm, \
     MandateEndForm, MandateForm, EmployeeForm, PersonPaymentForm, PersonStudyForm, PersonPreferencesForm, \
     SaveNewFirstModelFormSet, StudentForm
-from amelie.members.models import Payment, Committee, Function, Membership, Employee, Person, Student, \
+from amelie.members.models import Payment, Committee, Function, Membership, Employee, PaymentType, Person, Student, \
     StudyPeriod, Preference, PreferenceCategory
 from amelie.members.query_views import filter_member_list_public
 from amelie.personal_tab.models import Authorization
@@ -165,16 +165,21 @@ def person_membership_new(request, id):
 @require_committee(settings.ROOM_DUTY_ABBREVIATION)
 def person_membership_end(request, id):
     obj = get_object_or_404(Person, id=id)
+    membership = obj.membership_set.latest('year', 'pk')
     if request.method == "POST":
-        form = MembershipEndForm(request.POST, instance=obj.membership_set.latest('year'))
+        form = MembershipEndForm(request.POST, instance=membership)
         if form.is_valid():
+            if form.cleaned_data['payment_needed'] == False and not Payment.objects.filter(membership=membership).exists():
+                # If payment is not needed and payment does not exist yet, create one
+                # PaymentType is 10: "Voortijdige beëindiging, betaling niet noodzakelijk."
+                Payment.objects.create(membership=membership, payment_type=PaymentType.objects.get(pk=10), amount=membership.type.price, date=form.cleaned_data['ended'])
             form.save()
             return render(request, "person_membership.html", locals())
         else:
             response = render(request, "person_end_membership.html", locals())
             return response
     else:
-        form = MembershipEndForm(instance=obj.membership_set.latest('year'))
+        form = MembershipEndForm(instance=membership)
         return render(request, "person_end_membership.html", locals())
 
 

--- a/amelie/members/forms.py
+++ b/amelie/members/forms.py
@@ -288,10 +288,16 @@ class MembershipForm(forms.ModelForm):
 
 class MembershipEndForm(forms.ModelForm):
     ended = forms.DateField(widget=widgets.RadioSelect)
+    payment_needed = forms.BooleanField(
+        label=_l('Does the member still have to pay the membership fee?'),
+        widget=widgets.CheckboxInput,
+        initial=True,
+        required=False
+    )
 
     class Meta:
         model = Membership
-        fields = ("ended",)
+        fields = ("ended", "payment_needed")
 
     def __init__(self, *args, **kwargs):
         super(MembershipEndForm, self).__init__(*args, **kwargs)

--- a/amelie/members/templates/person_end_membership.html
+++ b/amelie/members/templates/person_end_membership.html
@@ -10,6 +10,11 @@
         {% csrf_token %}
         {{ form.ended.errors }}
         {{ form.ended }}
+        {{ form.payment_needed.errors }}
+        <label for="{{ form.payment_needed.id_for_label }}">
+            {{ form.payment_needed }}
+            {{ form.payment_needed.label }}
+        </label>
 
         <div class="buttons">
             <a href="{% url 'members:person_membership' obj.id %}" class="looks-like-a-button js-load-block" data-container="person_membership">


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
Added a checkmark for making a Payment object if payment is not needed when the membership is terminated. The PaymentType is "Voortijdig beeindigd".

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes #978

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
yes, one sentence.

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes
