### PR TITLE
Template issue when activating duplicate mandate

### DIFF
--- a/amelie/members/ajax_views.py
+++ b/amelie/members/ajax_views.py
@@ -216,9 +216,8 @@ def person_mandate_activate(request, id, mandate):
     mandate = get_object_or_404(Authorization, id=mandate, person=obj, end_date__isnull=True, is_signed=False)
 
     # If there is already an active mandate of this type, we cannot activate this one
-    if obj.authorization_set.filter(
-        is_signed=True, end_date__isnull=True, authorization_type=mandate.authorization_type
-    ).exists():
+    existing_mandates_of_type = obj.authorization_set.filter(is_signed=True, end_date__isnull=True, authorization_type=mandate.authorization_type)
+    if existing_mandates_of_type.exists():
         return render(request, "person_existing_mandate.html", locals())
 
     elif request.method == "POST":


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
 Fixing that the mandate reference was not visible when activating a duplicate mandate, as existing_mandates_of_type is a variable used in the template.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
None

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes
