### PR TITLE
Make personal tab direct debit above 250€ unselectable 

### DIFF
--- a/amelie/personal_tab/debt_collection.py
+++ b/amelie/personal_tab/debt_collection.py
@@ -1,6 +1,7 @@
 import datetime
 from datetime import timezone as tz
 
+from django.conf import settings
 from django.db.models import Sum, Q
 from django.template.defaultfilters import date as _date
 from django.utils import timezone, translation
@@ -205,7 +206,7 @@ def generate_cookie_corner_instructions(end_date):
         person = Person.objects.get(id=p['person'])
         transactions = all_transactions.filter(person=person)
         price = transactions.aggregate(Sum('price'))['price__sum']
-        sumf = ("%.2f" % price).replace('.', ',')
+        above_maximum = False
 
         if price == 0:
             continue
@@ -229,6 +230,9 @@ def generate_cookie_corner_instructions(end_date):
                 instruction = DebtCollectionInstruction(amount=price, authorization=authorization,
                                                         description=description,
                                                         amendment=authorization.next_amendment())
+            
+            if price > settings.MAXIMUM_DIRECT_DEBIT_AMOUNT:
+                above_maximum = True
 
         row = {
             'person': person,
@@ -236,7 +240,8 @@ def generate_cookie_corner_instructions(end_date):
             'sum': price,
             'sumf': sumf,
             'instruction': instruction,
-            'transactions': transactions
+            'transactions': transactions,
+            'above_maximum': above_maximum,
         }
 
         if price < 0:

--- a/amelie/personal_tab/debt_collection.py
+++ b/amelie/personal_tab/debt_collection.py
@@ -87,7 +87,7 @@ def generate_contribution_instructions(years):
     for m in memberships:
         person = m.member
         price = m.type.price
-        sumf = ("%.2f" % price).replace('.', ',')
+        sumf = ("%.2f" % price)
 
         authorization = authorization_contribution(person)
 
@@ -206,6 +206,7 @@ def generate_cookie_corner_instructions(end_date):
         person = Person.objects.get(id=p['person'])
         transactions = all_transactions.filter(person=person)
         price = transactions.aggregate(Sum('price'))['price__sum']
+        sumf = ("%.2f" % price)
         above_maximum = False
 
         if price == 0:

--- a/amelie/personal_tab/debt_collection.py
+++ b/amelie/personal_tab/debt_collection.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django.db import transaction
+from django.conf import settings
 from django.db.models import Sum, Q
 from django.template.defaultfilters import date as _date
 from django.utils import timezone, translation
@@ -188,9 +189,10 @@ def generate_cookie_corner_instructions(end_date):
         person = Person.objects.get(id=p['person'])
         transactions = all_transactions.filter(person=person)
         price = transactions.aggregate(Sum('price'))['price__sum']
+        above_maximum = False
 
         if price == 0:
-            continue
+            continue 
 
         authorization = authorization_cookie_corner(person)
         instruction = None
@@ -211,13 +213,17 @@ def generate_cookie_corner_instructions(end_date):
                 instruction = DebtCollectionInstruction(amount=price, authorization=authorization,
                                                         description=description,
                                                         amendment=authorization.next_amendment())
+            
+            if price > settings.MAXIMUM_DIRECT_DEBIT_AMOUNT:
+                above_maximum = True
 
         row = {
             'person': person,
             'authorization': authorization,
             'sum': price,
             'instruction': instruction,
-            'transactions': transactions
+            'transactions': transactions,
+            'above_maximum': above_maximum,
         }
 
         if price < 0:

--- a/amelie/personal_tab/templates/lists/debt_collection_proposal_contribution.html
+++ b/amelie/personal_tab/templates/lists/debt_collection_proposal_contribution.html
@@ -9,7 +9,7 @@
                     <th>{% trans 'Person' %}</th>
                     <th>{% trans 'Membership type' %}</th>
                     <th>{% trans 'Mandate' %}</th>
-                    <th class="number">{% trans 'Price' %}</th>
+                    <th class="align-right">{% trans 'Price' %}</th>
                 </tr>
             </thead>
             <tbody>
@@ -28,12 +28,16 @@
                     </td>
                     <td>{{ row.membership.type }}</td>
                     <td>
-                        <a href="{{ row.instruction.authorization.get_absolute_url }}">{{ row.instruction.authorization }}</a>
-                        {% if row.instruction.amendment %}
-                            (<abbr title="{% trans 'amendment' %}">{% trans 'A ' context 'amendment abbr' %}</abbr>)
+                        {% if row.authorization %}
+                            <a href="{{ row.authorization.get_absolute_url }}">{{ row.authorization }}</a>
+                            {% if row.instruction.amendment %}
+                                (<abbr title="{% trans 'amendment' %}">{% trans 'A ' context 'amendment abbr' %}</abbr>)
+                            {% endif %}
+                        {% else %}
+                            {% trans 'None' %}
                         {% endif %}
                     </td>
-                    <td class="number">{{ row.sumf }}</td>
+                    <td class="align-right">{{ row.sumf }}</td>
                 </tr>
                 <tr>
                     <td colspan="{% if enabled %}5{% else %}4{% endif %}">
@@ -50,7 +54,7 @@
                     <td>{% trans 'Total' %}</td>
                     <td></td>
                     <td></td>
-                    <td class="number">{{ total }}</td>
+                    <td class="align-right">{{ total }}</td>
                 </tr>
             </tfoot>
         </table>

--- a/amelie/personal_tab/templates/lists/debt_collection_proposal_cookie_corner.html
+++ b/amelie/personal_tab/templates/lists/debt_collection_proposal_cookie_corner.html
@@ -15,10 +15,14 @@
             {% for row in rows %}
                 <tr>
                     {% if enabled %}
-                        <td>
-                            <input type="checkbox" {% if default %}checked="checked"{% endif %}
-                                name="cookie_corner_{{ row.person.id }}" value="true"/>
-                        </td>
+                        {% if not row.above_maximum %}
+                            <td>
+                                <input type="checkbox" {% if default %}checked="checked"{% endif %}
+                                    name="cookie_corner_{{ row.person.id }}" value="true"/>
+                            </td>
+                        {% else %}
+                            <td></td>
+                        {% endif %}
                     {% endif %}
                     <td>
                         <a href="{{ row.person.get_absolute_url }}">
@@ -35,7 +39,11 @@
                 </tr>
                 <tr>
                     <td colspan="{% if enabled %}4{% else %}3{% endif %}">
-                        {{ row.instruction.description }}
+                        {% if not row.above_maximum %}
+                            {{ row.instruction.description }}
+                        {% else %}
+                            <b>{% blocktrans with maximum=maximum_debit_amount|floatformat:2 %}This persons balance is higher than &euro; {{ maximum }}, so they cannot be debited.{% endblocktrans %}</b>
+                        {% endif %}
                     </td>
                 </tr>
             {% endfor %}

--- a/amelie/personal_tab/templates/lists/debt_collection_proposal_cookie_corner.html
+++ b/amelie/personal_tab/templates/lists/debt_collection_proposal_cookie_corner.html
@@ -8,7 +8,7 @@
                     {% if enabled %}<th>{% trans 'Collect' %}</th>{% endif %}
                     <th>{% trans 'Person' %}</th>
                     <th>{% trans 'Mandate' %}</th>
-                    <th class="number">{% trans 'Price' %}</th>
+                    <th class="align-right">{% trans 'Price' %}</th>
                 </tr>
             </thead>
             <tbody>
@@ -39,7 +39,7 @@
                             {% trans 'None' %}
                         {% endif %}
                     </td>
-                    <td class="number">{{ row.sumf }}</td>
+                    <td class="align-right">{{ row.sumf }}</td>
                 </tr>
                 <tr>
                     <td colspan="{% if enabled %}4{% else %}3{% endif %}">
@@ -59,7 +59,7 @@
                     {% endif %}
                     <td>{% trans 'Total' %}</td>
                     <td></td>
-                    <td class="number">{{ total }}</td>
+                    <td class="align-right">{{ total }}</td>
                 </tr>
             </tfoot>
         </table>

--- a/amelie/personal_tab/templates/lists/debt_collection_proposal_cookie_corner.html
+++ b/amelie/personal_tab/templates/lists/debt_collection_proposal_cookie_corner.html
@@ -21,7 +21,9 @@
                                     name="cookie_corner_{{ row.person.id }}" value="true"/>
                             </td>
                         {% else %}
-                            <td></td>
+                            <td>
+                                <p class="icon icon-error"></p>
+                            </td>
                         {% endif %}
                     {% endif %}
                     <td>
@@ -46,7 +48,7 @@
                         {% if not row.above_maximum %}
                             {{ row.instruction.description }}
                         {% else %}
-                            <b>{% blocktrans with maximum=maximum_debit_amount|floatformat:2 %}This persons balance is higher than &euro; {{ maximum }}, so they cannot be debited.{% endblocktrans %}</b>
+                            <b>{% blocktrans with maximum=maximum_debit_amount|floatformat:2 %}This person's balance is higher than &euro; {{ maximum }}, so they cannot be debited.{% endblocktrans %}</b>
                         {% endif %}
                     </td>
                 </tr>

--- a/amelie/personal_tab/templates/lists/debt_collection_proposal_cookie_corner.html
+++ b/amelie/personal_tab/templates/lists/debt_collection_proposal_cookie_corner.html
@@ -30,9 +30,13 @@
                         </a>
                     </td>
                     <td>
-                        <a href="{{ row.authorization.get_absolute_url }}">{{ row.authorization }}</a>
-                        {% if row.instruction.amendment %}
-                            (<abbr title="{% trans 'amendment' %}">{% trans 'A ' context 'amendment abbr' %}</abbr>)
+                        {% if row.authorization %}
+                            <a href="{{ row.authorization.get_absolute_url }}">{{ row.authorization }}</a>
+                            {% if row.instruction.amendment %}
+                                (<abbr title="{% trans 'amendment' %}">{% trans 'A ' context 'amendment abbr' %}</abbr>)
+                            {% endif %}
+                        {% else %}
+                            {% trans 'None' %}
                         {% endif %}
                     </td>
                     <td class="number">{{ row.sumf }}</td>

--- a/amelie/personal_tab/templates/lists/debt_collection_proposal_cookie_corner.html
+++ b/amelie/personal_tab/templates/lists/debt_collection_proposal_cookie_corner.html
@@ -16,10 +16,14 @@
             {% for row in rows %}
                 <tr>
                     {% if enabled %}
-                        <td>
-                            <input type="checkbox" {% if default %}checked="checked"{% endif %}
-                                name="cookie_corner_{{ row.person.id }}" value="true"/>
-                        </td>
+                        {% if not row.above_maximum %}
+                            <td>
+                                <input type="checkbox" {% if default %}checked="checked"{% endif %}
+                                    name="cookie_corner_{{ row.person.id }}" value="true"/>
+                            </td>
+                        {% else %}
+                            <td></td>
+                        {% endif %}
                     {% endif %}
                     <td>
                         <a href="{{ row.person.get_absolute_url }}">
@@ -42,6 +46,15 @@
                         {% endif %}
                     </td>
                     <td class="align-right">&euro;&nbsp;{{ row.sum|intcomma }}</td>
+                </tr>
+                <tr>
+                    <td colspan="{% if enabled %}4{% else %}3{% endif %}">
+                        {% if not row.above_maximum %}
+                            {{ row.instruction.description }}
+                        {% else %}
+                            <b>{% blocktrans with maximum=maximum_debit_amount|floatformat:2 %}This persons balance is higher than &euro; {{ maximum }}, so they cannot be debited.{% endblocktrans %}</b>
+                        {% endif %}
+                    </td>
                 </tr>
                 {% if row.instruction.description %}
                     <tr>

--- a/amelie/personal_tab/templates/lists/debt_collection_proposal_cookie_corner.html
+++ b/amelie/personal_tab/templates/lists/debt_collection_proposal_cookie_corner.html
@@ -49,19 +49,14 @@
                     </td>
                     <td class="align-right">&euro;&nbsp;{{ row.sum|intcomma }}</td>
                 </tr>
-                <tr>
-                    <td colspan="{% if enabled %}4{% else %}3{% endif %}">
-                        {% if not row.above_maximum %}
+                {% if row.instruction.description %}
+                    <tr>
+                        <td colspan="{% if enabled %}4{% else %}3{% endif %}">
+                            {% if not row.above_maximum %}
                             {{ row.instruction.description }}
                         {% else %}
                             <b>{% blocktrans with maximum=maximum_debit_amount|floatformat:2 %}This person's balance is higher than &euro; {{ maximum }}, so they cannot be debited.{% endblocktrans %}</b>
                         {% endif %}
-                    </td>
-                </tr>
-                {% if row.instruction.description %}
-                    <tr>
-                        <td colspan="{% if enabled %}4{% else %}3{% endif %}">
-                            {{ row.instruction.description }}
                         </td>
                     </tr>
                 {% endif %}

--- a/amelie/personal_tab/templates/lists/debt_collection_proposal_cookie_corner.html
+++ b/amelie/personal_tab/templates/lists/debt_collection_proposal_cookie_corner.html
@@ -22,7 +22,9 @@
                                     name="cookie_corner_{{ row.person.id }}" value="true"/>
                             </td>
                         {% else %}
-                            <td></td>
+                            <td>
+                                <p class="icon icon-error"></p>
+                            </td>
                         {% endif %}
                     {% endif %}
                     <td>
@@ -52,7 +54,7 @@
                         {% if not row.above_maximum %}
                             {{ row.instruction.description }}
                         {% else %}
-                            <b>{% blocktrans with maximum=maximum_debit_amount|floatformat:2 %}This persons balance is higher than &euro; {{ maximum }}, so they cannot be debited.{% endblocktrans %}</b>
+                            <b>{% blocktrans with maximum=maximum_debit_amount|floatformat:2 %}This person's balance is higher than &euro; {{ maximum }}, so they cannot be debited.{% endblocktrans %}</b>
                         {% endif %}
                     </td>
                 </tr>

--- a/amelie/personal_tab/views.py
+++ b/amelie/personal_tab/views.py
@@ -1660,7 +1660,8 @@ def debt_collection_new(request):
         'contribution_instructions': contribution_instructions,
         'contribution_totals': contribution_totals,
         'cookie_corner_instructions': cookie_corner_instructions,
-        'cookie_corner_totals': cookie_corner_totals
+        'cookie_corner_totals': cookie_corner_totals,
+        'maximum_debit_amount': settings.MAXIMUM_DIRECT_DEBIT_AMOUNT,
     })
 
 

--- a/amelie/personal_tab/views.py
+++ b/amelie/personal_tab/views.py
@@ -2013,7 +2013,8 @@ def debt_collection_new(request):
         'contribution_instructions': contribution_instructions,
         'contribution_totals': contribution_totals,
         'cookie_corner_instructions': cookie_corner_instructions,
-        'cookie_corner_totals': cookie_corner_totals
+        'cookie_corner_totals': cookie_corner_totals,
+        'maximum_debit_amount': settings.MAXIMUM_DIRECT_DEBIT_AMOUNT,
     })
 
 

--- a/amelie/settings/environ.py
+++ b/amelie/settings/environ.py
@@ -488,6 +488,10 @@ PERSONAL_TAB_MAXIMUM_ACTIVITY_PRICE = Decimal(env("PERSONAL_TAB_MAXIMUM_ACTIVITY
 # Cookie corner Wrapped
 COOKIE_CORNER_WRAPPED_YEAR = env.int("COOKIE_CORNER_WRAPPED_YEAR", default=COOKIE_CORNER_WRAPPED_YEAR)
 
+# The maximum amount Inter-Actief can debit from a person per direct debit
+MAXIMUM_DIRECT_DEBIT_AMOUNT = Decimal(env("MAXIMUM_DIRECT_DEBIT_AMOUNT", default=MAXIMUM_DIRECT_DEBIT_AMOUNT))
+
+
 # Printer configuration
 
 # Maximum file size for printed files, in bytes (i.e. 50MB = 50 * 1024 * 1024 bytes)

--- a/amelie/settings/generic.py
+++ b/amelie/settings/generic.py
@@ -74,6 +74,9 @@ POOL_CATEGORY = "Pools"
 # The direct debit debtor ID of Inter-Actief that needs to be printed on the autorization forms
 DIRECT_DEBIT_DEBTOR_ID = 'NL81ZZZ400749470000'
 
+# The maximum amount Inter-Actief can debit from a person per direct debit
+MAXIMUM_DIRECT_DEBIT_AMOUNT = 250.00
+
 # The LDAP host that is used to verify login attempts in the LDAP authentication module
 LDAP_HOST = 'hexia.ia.utwente.nl'
 

--- a/amelie/settings/generic.py
+++ b/amelie/settings/generic.py
@@ -74,6 +74,9 @@ POOL_CATEGORY = "Pools"
 # The direct debit debtor ID of Inter-Actief that needs to be printed on the autorization forms
 DIRECT_DEBIT_DEBTOR_ID = 'NL81ZZZ400749470000'
 
+# The maximum amount Inter-Actief can debit from a person per direct debit
+MAXIMUM_DIRECT_DEBIT_AMOUNT = 250.00
+
 # The ID of the personal_tab.PaymentMethod object representing an early termination (no payment needed).
 MEMBERS_EARLY_TERMINATION_PAYMENT_METHOD_ID = 10
 # The ID of the personal_tab.PaymentMethod object representing a Forgiven payment (no payment needed).


### PR DESCRIPTION
Please add the following information to your pull request:

**Please describe what your PR is fixing**
This PR adds a variable upto which the personal tab of a person can be direct debited, after which the person becomes unselectable for a direct debit with a small explanation as to why.

Also some additional personal tab template fixes.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes #1286

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
yes, one new sentence

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
yes, the addition of the MAXIMUM_DIRECT_DEBIT_AMOUNT setting

**Did you properly test your PR before submitting it?**
yes
