### PR TITLE
Making ended memberships selectable for direct debits

### DIFF
--- a/amelie/personal_tab/debt_collection.py
+++ b/amelie/personal_tab/debt_collection.py
@@ -74,8 +74,7 @@ def generate_contribution_instructions(years):
 
     The DebtCollectionInstruction objects that are returned are not saved yet.
     """
-    memberships = Membership.objects.filter(Q(ended__gt=datetime.date.today()) | Q(ended__isnull=True),
-                                            payment__isnull=True, type__price__gt=0, year__in=years)
+    memberships = Membership.objects.filter(payment__isnull=True, type__price__gt=0, year__in=years)
     
     result = {
         'ongoing_frst': [],


### PR DESCRIPTION
**Please describe what your PR is fixing**
When creating a proposal for a direct debit, memberships which have ended, but do not have a payment are now selectable for the direct debit. 

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References Inter-Actief/amelie#<issue_id>`)**
Fixes #1301

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR include the proper translations (did you add translations for new/modified strings)?**
no

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no

**Does your PR need external actions by for example the System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
no

**Did you properly test your PR before submitting it?**
yes
