### PR TITLE
Fix incorrect contribution statistics

### DIFF
--- a/amelie/personal_tab/debt_collection.py
+++ b/amelie/personal_tab/debt_collection.py
@@ -1,5 +1,6 @@
 import datetime
 
+from django.conf import settings
 from django.db import transaction
 from django.db.models import Sum, Q
 from django.template.defaultfilters import date as _date
@@ -8,7 +9,8 @@ from django.utils.translation import gettext as _
 
 from amelie.members.models import Person, Membership
 from amelie.personal_tab.models import Transaction, DebtCollectionInstruction, DebtCollectionBatch, \
-    DebtCollectionTransaction, ContributionTransaction, ReversalTransaction, Reversal, Amendment, BadBIC
+    DebtCollectionTransaction, ContributionTransaction, ReversalTransaction, Reversal, Amendment, BadBIC, PaymentMethod, \
+    ManualPaymentSettlement
 from amelie.tools.encodings import normalize_to_ascii
 
 
@@ -313,13 +315,31 @@ def process_reversal(reversal, actor):
         #       albertskja - 2026-07-22
 
         # Create a ContributionTransaction to reverse the original transaction which was marked paid in the debt collection instruction
-        cct = ContributionTransaction(date=reversal_datetime, price=-ct.price, person=ct.person,
-                                      description=description, membership=ct.membership)
-        cct.save()
+        neg_cct = ContributionTransaction(date=reversal_datetime, price=-ct.price, person=ct.person,
+                                          description=description, membership=ct.membership)
+        neg_cct.save()
         # And create another ContributionTransaction to mark that the contribution still needs to be paid.
-        cct = ContributionTransaction(date=reversal_datetime, price=ct.price, person=ct.person,
-                                      description=ct.description, membership=ct.membership)
-        cct.save()
+        pos_cct = ContributionTransaction(date=reversal_datetime, price=ct.price, person=ct.person,
+                                          description=ct.description, membership=ct.membership)
+        pos_cct.save()
+
+        # Create a settlement to cancel out the ReversalTransaction against the negative ContributionTransaction.
+        payment_method = PaymentMethod.objects.get(pk=settings.INTERNAL_SETTLEMENT_PAYMENT_METHOD_ID)
+        # Translate the description to the user's preferred language
+        with translation.override(ct.person.preferred_language):
+            settlement_description = _(
+                "Internal settlement for reversed contribution {membership_type} ({start_year}/{end_year})").format(
+                membership_type=ct.membership.type.name, start_year=ct.membership.year,
+                end_year=ct.membership.year + 1
+            )
+            ManualPaymentSettlement.create_for_transactions(
+                transactions=[rt, neg_cct],
+                payment_method=payment_method,
+                person=ct.person,
+                settlement_description=settlement_description,
+                payment_description=settlement_description,
+                created_by=actor,
+            )
 
     # If the reversal reason is DNOR, the BIC of the authorization must be added to the Bad BIC list
     if reversal.reason == Reversal.ReversalReasons.DNOR:
@@ -361,6 +381,19 @@ def delete_reversal(reversal):
     # TODO: This next bit is a bit convoluted, but we need to clean up what we did in `process_reversal`.
     #       Maybe another refactor step is necessary to get rid of all of this hassle with ContributionTransactions.
     #       albertskja - 2026-07-22
+
+    # If the reversaltransaction was settled with a ManualPaymentSettlement, and the only other transaction in
+    # that settlement was a negative contributiontransaction for the same membership, on the same date,
+    # delete the settlement so the transactions can be deleted as well.
+    reversal_ct = ContributionTransaction.objects.filter(settlement=reversal.instruction, price__gt=0).first()
+    if reversal_ct is not None and rt.settlement is not None and hasattr(rt.settlement, 'manualpaymentsettlement'):
+        mps: ManualPaymentSettlement = rt.settlement.manualpaymentsettlement
+        if mps.transactions.count() == 2 and mps.transactions.filter(price=-rt.price, date=rt.date, person=reversal_ct.person, contributiontransaction__membership=reversal_ct.membership).exists():
+            # First, unlink transactions in the settlement from the settlement to avoid triggering PROTECT on delete
+            for t in mps.transactions.all():
+                t.settlement = None
+                t.save()
+            mps.delete()
 
     # If there were any (positive) contribution transactions in the original instruction, we need to delete the
     # contribution transactions that were created to reverse that payment and re-incur it. We assume that

--- a/amelie/personal_tab/statistics.py
+++ b/amelie/personal_tab/statistics.py
@@ -1,6 +1,8 @@
 from decimal import Decimal
+from typing import Dict, Set
 
-from django.db.models import Count, Sum
+from django.conf import settings
+from django.db.models import Count, Sum, Q
 from django.db.models.functions import TruncDay
 from django.utils.translation import gettext_lazy as _l
 
@@ -8,7 +10,7 @@ from amelie.calendar.models import Event
 from amelie.members.models import MembershipType
 from amelie.personal_tab.models import Discount, DiscountPeriod, CustomTransaction, DiscountCredit, \
     ContributionTransaction, AlexiaTransaction, ActivityTransaction, \
-    CookieCornerTransaction, LedgerAccount, Category, Article
+    CookieCornerTransaction, LedgerAccount, Category, Article, PaymentMethod
 
 
 def statistics_totals(start, end, tables):
@@ -170,37 +172,97 @@ def statistics_activities_total(start, end):
 
 
 def statistics_contribution_transactions(start, end):
-    contribution_transactions = ContributionTransaction.objects.filter(date__gte=start, date__lt=end)
-    contribution_sum = contribution_transactions.aggregate(Sum('price'))['price__sum'] or Decimal("0.00")
+    # Contribution transactions are a bit special. The ContributionTransaction is made when the membership is created,
+    # but in this view we are interested in which memberships were paid in the selected period.
+    # So, we need to look at the dates of the DebtCollectionInstructions and the ManualPaymentSettlements instead.
+
+    # We want to view the amounts for memberships that were paid with a mandate, manually, or forgiven.
+    # - Transactions paid with a mandate have a DebtCollectionInstruction OR are negative and have a ManualPaymentSettlement.
+    # - Transactions that were forgiven are positive and will have a ManualPaymentSettlements with the payment method "Forgiven" or "Early termination"
+    # - Transactions paid manually are positive and will have a ManualPaymentSettlements with any payment method that is not "Forgiven" or "Early termination"
+    pm_forgiven = PaymentMethod.objects.get(pk=settings.MEMBERS_FORGIVEN_PAYMENT_METHOD_ID)
+    pm_early_termination = PaymentMethod.objects.get(pk=settings.MEMBERS_EARLY_TERMINATION_PAYMENT_METHOD_ID)
+
+    mandate_transactions = ContributionTransaction.objects.filter(
+        Q(
+            settlement__debtcollectioninstruction__batch__execution_date__gte=start,
+            settlement__debtcollectioninstruction__batch__execution_date__lt=end
+        ) | Q(
+            price__lt=Decimal("0.00"),
+            settlement__manualpaymentsettlement__payment_date__gte=start,
+            settlement__manualpaymentsettlement__payment_date__lt=end,
+        )
+    ).distinct()
+    forgiven_transactions = ContributionTransaction.objects.filter(
+        price__gte=Decimal("0.00"),
+        settlement__manualpaymentsettlement__payment_date__gte=start,
+        settlement__manualpaymentsettlement__payment_date__lt=end,
+        settlement__manualpaymentsettlement__payment_method__in=[pm_forgiven, pm_early_termination]
+    ).distinct()
+    manual_transactions = ContributionTransaction.objects.filter(
+        price__gte=Decimal("0.00"),
+        settlement__manualpaymentsettlement__payment_date__gte=start,
+        settlement__manualpaymentsettlement__payment_date__lt=end
+    ).exclude(
+        settlement__manualpaymentsettlement__payment_method__in=[pm_forgiven, pm_early_termination]
+    ).distinct()
+    transaction_sums = {
+        'mandate': mandate_transactions.aggregate(Sum('price'))['price__sum'] or Decimal("0.00"),
+        'forgiven': forgiven_transactions.aggregate(Sum('price'))['price__sum'] or Decimal("0.00"),
+        'manual': manual_transactions.aggregate(Sum('price'))['price__sum'] or Decimal("0.00")
+    }
 
     # Do not use order, so that values works well. See Django manual.
-    sum_per_membership_type = contribution_transactions.order_by().values('membership__type').annotate(Sum('price'))
-    sum_per_membership_type_dict = {x['membership__type']: x['price__sum'] for x in sum_per_membership_type}
+    membership_types: Set[MembershipType] = set(x['membership__type'] for x in ContributionTransaction.objects.all().values('membership__type').distinct())
+    sum_per_membership_type_dict: Dict[MembershipType, dict] = {mtype: {} for mtype in membership_types}
+    for x in mandate_transactions.order_by().values('membership__type').annotate(Sum('price')):
+        sum_per_membership_type_dict[x['membership__type']].update({'mandate': x['price__sum'] or Decimal("0.00")})
+    for x in forgiven_transactions.order_by().values('membership__type').annotate(Sum('price')):
+        sum_per_membership_type_dict[x['membership__type']].update({'forgiven': x['price__sum'] or Decimal("0.00")})
+    for x in manual_transactions.order_by().values('membership__type').annotate(Sum('price')):
+        sum_per_membership_type_dict[x['membership__type']].update({'manual': x['price__sum'] or Decimal("0.00")})
 
     # Count positive and negative transactions
-    positive_transactions_per_membership_type = contribution_transactions.filter(price__gt=0).order_by().values(
-        'membership__type').annotate(Count('price'))
-    positive_transactions_per_membership_type_dict = {x['membership__type']: x['price__count'] or 0
-                                                      for x in positive_transactions_per_membership_type}
-    negative_transactions_per_membership_type = contribution_transactions.filter(price__lt=0).order_by().values(
-        'membership__type').annotate(Count('price'))
-    negative_transactions_per_membership_type_dict = {x['membership__type']: x['price__count'] or 0
-                                                      for x in negative_transactions_per_membership_type}
+    positive_transactions_per_membership_type_dict: Dict[MembershipType, dict] = {mtype: {} for mtype in membership_types}
+    for x in mandate_transactions.filter(price__gt=0).order_by().values('membership__type').annotate(Count('price')):
+        positive_transactions_per_membership_type_dict[x['membership__type']].update({'mandate': x['price__count'] or 0})
+    for x in forgiven_transactions.filter(price__gt=0).order_by().values('membership__type').annotate(Count('price')):
+        positive_transactions_per_membership_type_dict[x['membership__type']].update({'forgiven': x['price__count'] or 0})
+    for x in manual_transactions.filter(price__gt=0).order_by().values('membership__type').annotate(Count('price')):
+        positive_transactions_per_membership_type_dict[x['membership__type']].update({'manual': x['price__count'] or 0})
+
+    negative_transactions_per_membership_type_dict: Dict[MembershipType, dict] = {mtype: {} for mtype in membership_types}
+    for x in mandate_transactions.filter(price__lt=0).order_by().values('membership__type').annotate(Count('price')):
+        negative_transactions_per_membership_type_dict[x['membership__type']].update({'mandate': x['price__count'] or 0})
+    for x in forgiven_transactions.filter(price__lt=0).order_by().values('membership__type').annotate(Count('price')):
+        negative_transactions_per_membership_type_dict[x['membership__type']].update({'forgiven': x['price__count'] or 0})
+    for x in manual_transactions.filter(price__lt=0).order_by().values('membership__type').annotate(Count('price')):
+        negative_transactions_per_membership_type_dict[x['membership__type']].update({'manual': x['price__count'] or 0})
 
     types = MembershipType.objects.filter(pk__in=sum_per_membership_type_dict.keys())
 
     type_totals = []
 
     for membership_type in types:
-        if sum_per_membership_type_dict[membership_type.pk]:
-            positive_transactions = positive_transactions_per_membership_type_dict.get(membership_type.pk, 0)
-            negative_transactions = negative_transactions_per_membership_type_dict.get(membership_type.pk, 0)
-            type_totals.append({
-                'membership_type': membership_type,
-                'amount': positive_transactions - negative_transactions,
-                'total': sum_per_membership_type_dict[membership_type.pk]
-            })
-    return {'rows': type_totals, 'sum': contribution_sum}
+        sums_of_type = sum_per_membership_type_dict[membership_type.pk]
+        positives_of_type = positive_transactions_per_membership_type_dict.get(membership_type.pk, {})
+        negatives_of_type = negative_transactions_per_membership_type_dict.get(membership_type.pk, {})
+        if all(v == 0 for v in positives_of_type.values()) and all(v == 0 for v in negatives_of_type.values()):
+            # No transactions for this membership type, skip adding to table
+            continue
+        type_totals.append({
+            'membership_type': membership_type,
+            'counts': {
+                k: positives_of_type.get(k, 0) - negatives_of_type.get(k, 0)
+                for k in set(positives_of_type.keys()).union(set(negatives_of_type.keys()))
+            },
+            'totals': sums_of_type
+        })
+    return {
+        'rows': type_totals,
+        'sums': transaction_sums,
+        'sum': sum(x for x in transaction_sums.values()),
+    }
 
 
 def statistics_contribution_transactions_total(start, end):

--- a/amelie/personal_tab/statistics.py
+++ b/amelie/personal_tab/statistics.py
@@ -252,10 +252,8 @@ def statistics_contribution_transactions(start, end):
             continue
         type_totals.append({
             'membership_type': membership_type,
-            'counts': {
-                k: positives_of_type.get(k, 0) - negatives_of_type.get(k, 0)
-                for k in set(positives_of_type.keys()).union(set(negatives_of_type.keys()))
-            },
+            'positive_counts': positives_of_type,
+            'negative_counts': negatives_of_type,
             'totals': sums_of_type
         })
     return {

--- a/amelie/personal_tab/templates/debt_collection/view.html
+++ b/amelie/personal_tab/templates/debt_collection/view.html
@@ -102,6 +102,13 @@
                                             <a href="{{ instruction.get_absolute_url }}">
                                                 {{ instruction.debt_collection_reference }}
                                             </a>
+                                            {% if instruction.reversal %}
+                                                &nbsp;
+                                                <a href="{% url 'personal_tab:reversal_transaction_detail' instruction.reversal.transaction.pk %}" target="_blank"
+                                                   title="{% trans 'This instruction was reversed, click to view the reversal transaction in a new tab.' %}">
+                                                <i class="icon icon-arrow_redo"></i>
+                                                </a>
+                                            {% endif %}
                                         </td>
                                         <td>
                                             {% if instruction.authorization.person %}

--- a/amelie/personal_tab/templates/statistics/statistics.html
+++ b/amelie/personal_tab/templates/statistics/statistics.html
@@ -292,9 +292,9 @@
                                 {% for row in tables.c.rows %}
                                     <tr>
                                         <td>{{ row.membership_type }}</td>
-                                        <td class="align-right"><small>({% blocktrans with c=row.counts.mandate|default:0 %}{{ c }}x{% endblocktrans %})</small>&nbsp;&euro;&nbsp;{{ row.totals.mandate|intcomma|default:'-' }}</td>
-                                        <td class="align-right"><small>({% blocktrans with c=row.counts.manual|default:0 %}{{ c }}x{% endblocktrans %})</small>&nbsp;&euro;&nbsp;{{ row.totals.manual|intcomma|default:'-' }}</td>
-                                        <td class="align-right"><small>({% blocktrans with c=row.counts.forgiven|default:0 %}{{ c }}x{% endblocktrans %})</small>&nbsp;&euro;&nbsp;{{ row.totals.forgiven|intcomma|default:'-' }}</td>
+                                        <td class="align-right"><small>{% blocktrans with pos_c=row.positive_counts.mandate|default:0 neg_c=row.negative_counts.mandate|default:0 %}(+{{ pos_c }}, -{{ neg_c }}){% endblocktrans %}</small>&nbsp;&euro;&nbsp;{{ row.totals.mandate|intcomma|default:'-' }}</td>
+                                        <td class="align-right"><small>{% blocktrans with pos_c=row.positive_counts.manual|default:0 neg_c=row.negative_counts.manual|default:0 %}(+{{ pos_c }}, -{{ neg_c }}){% endblocktrans %}</small>&nbsp;&euro;&nbsp;{{ row.totals.manual|intcomma|default:'-' }}</td>
+                                        <td class="align-right"><small>{% blocktrans with pos_c=row.positive_counts.forgiven|default:0 neg_c=row.negative_counts.forgiven|default:0 %}(+{{ pos_c }}, -{{ neg_c }}){% endblocktrans %}</small>&nbsp;&euro;&nbsp;{{ row.totals.forgiven|intcomma|default:'-' }}</td>
                                     </tr>
                                 {% endfor %}
                                 <tr class="text-bold">

--- a/amelie/personal_tab/templates/statistics/statistics.html
+++ b/amelie/personal_tab/templates/statistics/statistics.html
@@ -276,29 +276,36 @@
         {% if tables.c %}
             <div class="col-xs-12">
                 <div class="ia">
-                    <h2>{% trans 'Membership fee' %}</h2>
+                    <h2>{% trans 'Paid membership fees' %}</h2>
                     <div class="content">
                         <div class="table-responsive">
                             <table class="table">
                                 <thead>
                                 <tr>
                                     <th>{% trans 'Membership type' %}</th>
-                                    <th class="align-right">{% trans 'Amount' %}</th>
-                                    <th class="align-right">{% trans 'Price' %}</th>
+                                    <th class="align-right">{% trans 'Paid by mandate' %}</th>
+                                    <th class="align-right">{% trans 'Paid manually' %}</th>
+                                    <th class="align-right">{% trans 'Forgiven / early termination' %}</th>
                                 </tr>
                                 </thead>
                                 <tbody>
                                 {% for row in tables.c.rows %}
                                     <tr>
                                         <td>{{ row.membership_type }}</td>
-                                        <td class="align-right">{{ row.amount }}</td>
-                                        <td class="align-right">&euro;&nbsp;{{ row.total|intcomma }}</td>
+                                        <td class="align-right"><small>({% blocktrans with c=row.counts.mandate|default:0 %}{{ c }}x{% endblocktrans %})</small>&nbsp;&euro;&nbsp;{{ row.totals.mandate|intcomma|default:'-' }}</td>
+                                        <td class="align-right"><small>({% blocktrans with c=row.counts.manual|default:0 %}{{ c }}x{% endblocktrans %})</small>&nbsp;&euro;&nbsp;{{ row.totals.manual|intcomma|default:'-' }}</td>
+                                        <td class="align-right"><small>({% blocktrans with c=row.counts.forgiven|default:0 %}{{ c }}x{% endblocktrans %})</small>&nbsp;&euro;&nbsp;{{ row.totals.forgiven|intcomma|default:'-' }}</td>
                                     </tr>
                                 {% endfor %}
                                 <tr class="text-bold">
                                     <td>{% trans 'Total' %}</td>
-                                    <td class="align-right"></td>
-                                    <td class="align-right">&euro;&nbsp;{{ tables.c.sum|intcomma }}</td>
+                                    <td class="align-right">&euro;&nbsp;{{ tables.c.sums.mandate|intcomma }}</td>
+                                    <td class="align-right">&euro;&nbsp;{{ tables.c.sums.manual|intcomma }}</td>
+                                    <td class="align-right">&euro;&nbsp;{{ tables.c.sums.forgiven|intcomma }}</td>
+                                </tr>
+                                <tr class="text-bold">
+                                    <td>{% trans 'Full total' %}</td>
+                                    <td colspan="3" class="align-right">&euro;&nbsp;{{ tables.c.sum|intcomma }}</td>
                                 </tr>
                                 </tbody>
                             </table>


### PR DESCRIPTION

**Please describe what your PR is fixing**
- Fix incorrect contribution statistics used by treasurer to fill bookkeeping
- Automatically settle reversaltransactions for contribution against the negative contributiontransaction when creating a reversal for a contribution direct debit instruction.

**Concretely, which issues does your PR solve? (Please reference them by typing `Fixes/References #<issue_id>`)**
Fixes #1339 

**Does your PR change how we process personal data, impact our [privacy document](https://www.inter-actief.utwente.nl/privacy/), or modify (one of) our data export(s)?**
no

**Does your PR include any django migrations?**
no

**Does your PR add/modify translatable strings? These must be translated with [Weblate](https://weblate.ia.utwente.nl/projects/amelie/-/en/) once the PR has merged.**
yes

**Does your PR include CSS changes (and did you run the `compile_css.sh` script in the `scripts` directory to regenerate the `compiled.css` file)?**
no, my PR does not include CSS changes

**Does your PR need external actions by for example the WWW-Supers or System Administrators? (Think about new pip packages, new (local) settings, a new regular task or cronjob, new management commands, etc.)?**
yes, check for any unsettled negative contributiontransactions in prod, and create a settlement for them against their reversaltransaction. This was not done automatically for new reversals since the big settlement migration until this PR.

**Did you properly test your PR before submitting it?**
yes
